### PR TITLE
Ptp support

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -145,6 +145,13 @@ for cfg in sensorConfigList:
 
     gen.add("network_time_sync", bool_t, 0, "NetworkTimeSynchronization", True);
 
+    if cfg.name.find('s27_sgm_AR0234'):
+        gen.add("ptp_time_sync", bool_t, 0, "PTPTimeSynchronization", False);
+        trigger_source_enum = gen.enum([ gen.const("internal", int_t, 0, ""),
+                                         gen.const("ptp", int_t, 3, "")],
+                                         "Trigger sources");
+        gen.add("trigger_source", int_t, 0, "Trigger Source", 0, edit_method=trigger_source_enum)
+
     if cfg.imu:
         gen.add("imu_samples_per_message", int_t, 0, "ImuSamplesPerMessage", 30, 1, 300)
         gen.add("accelerometer_enabled", bool_t, 0, "AcceleromterEnabled", True)

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -26,7 +26,7 @@ sensorConfigList.append(SensorConfig(name="sl_sgm_cmv4000_imu", sgm=True, imu=Tr
 sensorConfigList.append(SensorConfig(name="st21_sgm_vga_imu",   sgm=True, imu=True))
 sensorConfigList.append(SensorConfig(name="mono_cmv2000",       sgm=False, imu=True))
 sensorConfigList.append(SensorConfig(name="mono_cmv4000",       sgm=False, imu=True))
-sensorConfigList.append(SensorConfig(name="s27_sgm_AR0234", sgm=True, imu=False))
+sensorConfigList.append(SensorConfig(name="s27_sgm_AR0234",     sgm=True, imu=False))
 
 for cfg in sensorConfigList:
     gen = ParameterGenerator()
@@ -112,8 +112,8 @@ for cfg in sensorConfigList:
     gen.add("desired_transmit_delay", int_t, 0, "desired_transmit_delay (ms)", 0, 0, 500)
 
     if "sgm_cmv4000" in cfg.name or "sgm_AR0234" in cfg.name:
-     gen.add("crop_mode", bool_t, 0, "Crop image to 2MP", False)
-     gen.add("crop_offset", int_t, 0, "Crop Offset", 480, 0, 960)
+        gen.add("crop_mode", bool_t, 0, "Crop image to 2MP", False)
+        gen.add("crop_offset", int_t, 0, "Crop Offset", 480, 0, 960)
     #endif
 
     if cfg.name.find('st21_sgm_vga_imu') == -1:
@@ -145,7 +145,7 @@ for cfg in sensorConfigList:
 
     gen.add("network_time_sync", bool_t, 0, "NetworkTimeSynchronization", True);
 
-    if cfg.name.find('s27_sgm_AR0234'):
+    if cfg.name.find('s27_sgm_AR0234') != -1:
         gen.add("ptp_time_sync", bool_t, 0, "PTPTimeSynchronization", False);
         trigger_source_enum = gen.enum([ gen.const("internal", int_t, 0, ""),
                                          gen.const("ptp", int_t, 3, "")],

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -142,6 +142,7 @@ private:
     bool lighting_supported_ = false;
     bool motor_supported_ = false;
     bool crop_mode_changed_ = false;
+    bool ptp_supported_ = false;
 
     //
     // Cached value for the boarder clip. These are used to determine if we

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -96,6 +96,7 @@ private:
     template<class T> void configureImu(const T& dyn);
     template<class T> void configureBorderClip(const T& dyn);
     template<class T> void configurePointCloudRange(const T& dyn);
+    template<class T> void configurePtp(const T& dyn);
 
     //
     // CRL sensor API

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -81,7 +81,7 @@ Reconfigure::Reconfigure(Channel* driver,
     {
         motor_supported_ = true;
     }
-    if (system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7AR == deviceInfo.hardwareRevision ||
+    if (system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27 == deviceInfo.hardwareRevision ||
         system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30 == deviceInfo.hardwareRevision ||
         system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21 == deviceInfo.hardwareRevision)
     {

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -566,6 +566,21 @@ template<class T> void Reconfigure::configurePointCloudRange(const T& dyn)
     max_point_cloud_range_callback_(dyn.max_point_cloud_range);
 }
 
+template<class T> void Reconfigure::configurePtp(const T& dyn)
+{
+    Status status = driver_->setTriggerSource(dyn.trigger_source);
+    if (Status_Ok != status) {
+            ROS_ERROR("Reconfigure: failed to set trigger source: %s",
+                      Channel::statusString(status));
+    }
+
+    status = driver_->ptpTimeSynchronization(dyn.ptp_time_sync);
+    if (Status_Ok != status) {
+            ROS_ERROR("Reconfigure: enable PTP time synchronization: %s",
+                      Channel::statusString(status));
+    }
+}
+
 
 #define GET_CONFIG()                                                    \
     image::Config cfg;                                                  \
@@ -625,6 +640,14 @@ template<class T> void Reconfigure::configurePointCloudRange(const T& dyn)
         configurePointCloudRange(dyn);                          \
     } while(0)
 
+#define S27_SGM()  do {                              \
+        GET_CONFIG();                                           \
+        configureSgm(cfg, dyn);                                 \
+        configureCamera(cfg, dyn);                              \
+        configureBorderClip(dyn);                               \
+        configurePtp(dyn);                                      \
+    } while(0)
+
 
 
 //
@@ -638,7 +661,7 @@ void Reconfigure::callback_sl_sgm_cmv2000_imu (multisense_ros::sl_sgm_cmv2000_im
 void Reconfigure::callback_sl_sgm_cmv4000_imu (multisense_ros::sl_sgm_cmv4000_imuConfig& dyn, uint32_t level) { (void) level; SL_SGM_IMU_CMV4000();  }
 void Reconfigure::callback_mono_cmv2000       (multisense_ros::mono_cmv2000Config&       dyn, uint32_t level) { (void) level; SL_BM_IMU();   }
 void Reconfigure::callback_mono_cmv4000       (multisense_ros::mono_cmv4000Config&       dyn, uint32_t level) { (void) level; SL_BM_IMU();   }
-void Reconfigure::callback_s27_AR0234         (multisense_ros::s27_sgm_AR0234Config&     dyn, uint32_t level) { (void) level; SL_SGM();   }
+void Reconfigure::callback_s27_AR0234         (multisense_ros::s27_sgm_AR0234Config&     dyn, uint32_t level) { (void) level; S27_SGM();   }
 
 //
 // BCAM (Sony IMX104)


### PR DESCRIPTION
Expose PTP support via the ROS driver. This allows the user to either enable/disable PTP synchronization, and enable PTP capture synchronization across multiple cameras. 