### PR TITLE
Enable stereo profile support via dynamic reconfigure

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -152,6 +152,12 @@ for cfg in sensorConfigList:
                                          "Trigger sources");
         gen.add("trigger_source", int_t, 0, "Trigger Source", 0, edit_method=trigger_source_enum)
 
+        stereo_profile_enum = gen.enum([ gen.const("user_control", int_t, 0, ""),
+                                         gen.const("detail_disparity", int_t, 1, ""),
+                                         gen.const("high_contrast", int_t, 2, "")],
+                                         "Trigger sources");
+        gen.add("stereo_profile", int_t, 0, "Stereo Profile", 0, edit_method=stereo_profile_enum)
+
     if cfg.imu:
         gen.add("imu_samples_per_message", int_t, 0, "ImuSamplesPerMessage", 30, 1, 300)
         gen.add("accelerometer_enabled", bool_t, 0, "AcceleromterEnabled", True)

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -97,6 +97,7 @@ private:
     template<class T> void configureBorderClip(const T& dyn);
     template<class T> void configurePointCloudRange(const T& dyn);
     template<class T> void configurePtp(const T& dyn);
+    template<class T> void configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn);
 
     //
     // CRL sensor API

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -599,6 +599,10 @@ template<class T> void Reconfigure::configurePtp(const T& dyn)
     }
 }
 
+template<class T> void Reconfigure::configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn)
+{
+    cfg.setCameraProfile(dyn.stereo_profile);
+}
 
 #define GET_CONFIG()                                                    \
     image::Config cfg;                                                  \
@@ -658,9 +662,10 @@ template<class T> void Reconfigure::configurePtp(const T& dyn)
         configurePointCloudRange(dyn);                          \
     } while(0)
 
-#define S27_SGM()  do {                              \
+#define S27_SGM()  do {                                         \
         GET_CONFIG();                                           \
         configureSgm(cfg, dyn);                                 \
+        configureStereoProfile(cfg, dyn);                       \
         configureCamera(cfg, dyn);                              \
         configureBorderClip(dyn);                               \
         configurePtp(dyn);                                      \


### PR DESCRIPTION
Enable the stereo camera profile settings via dynamic reconfigure. This is only supported for the next generation of stereo cameras. 