### PR TITLE
Enable auto exposure ROI via dynamic reconfigure

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -129,6 +129,11 @@ for cfg in sensorConfigList:
         gen.add("white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
         gen.add("white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
         gen.add("hdr_enable", bool_t, 0, "HDR Enable", False)
+        gen.add("roi_auto_exposure", bool_t, 0, "RoiAutoExposure", False)
+        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
+        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 2048)
+        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
+        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 2048)
     #endif
 
     if cfg.sgm:

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -157,6 +157,7 @@ for cfg in sensorConfigList:
         gen.add("white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
         gen.add("white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
         gen.add("hdr_enable", bool_t, 0, "HDR Enable", False)
+        gen.add("roi_auto_exposure", bool_t, 0, "RoiAutoExposure", False)
     #endif
 
     if cfg.sgm:

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -47,6 +47,10 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x128", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
+        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
+        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 1088)
+        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
+        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 1088)
     elif cfg.name.find('sgm_cmv4000') != -1:
         res_enum = gen.enum([ gen.const("1024x512_64_disparities", str_t, "1024x512x64", "1024x512x64"),
                               gen.const("1024x512_128_disparities", str_t, "1024x512x128", "1024x512x128"),
@@ -63,18 +67,30 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x128", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
+        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
+        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 2048)
+        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
+        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 2048)
     elif cfg.name.find('bm_cmv2000') != -1:
         res_enum = gen.enum([ gen.const("1024x544_128_disparities", str_t, "1024x544x128", "1024x544x128"),
                               gen.const("2048x1088_No_disparities", str_t, "2048x1088x0", "2048x1088x0") ],
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x128", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
+        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
+        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 1088)
+        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
+        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 1088)
     elif cfg.name.find('bm_cmv4000') != -1:
         res_enum = gen.enum([ gen.const("1024x1024_128_disparities", str_t, "1024x1024x128", "1024x1024x128"),
                               gen.const("2048x2048_No_disparities", str_t, "2048x2048x0", "2048x2048x0") ],
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x128", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
+        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
+        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 2048)
+        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
+        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 2048)
     elif cfg.name.find('st21_sgm_vga_imu') != -1:
         res_enum = gen.enum([ gen.const("640x512_64_disparities", str_t, "640x512x64", "640x512x64"),
                               gen.const("640x512_128_disparities", str_t, "640x512x128", "640x512x128") ],
@@ -89,6 +105,10 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x0", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
+        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
+        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 1088)
+        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
+        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 1088)
     elif cfg.name.find('mono_cmv4000') != -1:
         res_enum = gen.enum([ gen.const("1024x512", str_t, "1024x512x0", "1024x512x0"),
                               gen.const("1024x1024", str_t, "1024x1024x0", "1024x1024x0"),
@@ -97,6 +117,10 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x0", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
+        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
+        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 2048)
+        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
+        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 2048)
     elif cfg.name.find('sgm_AR0234') != -1:
         res_enum = gen.enum([ gen.const("960x600_64_disparities", str_t, "960x600x64", "960x600x64"),
                               gen.const("960x600_128_disparities", str_t, "960x600x128", "960x600x128"),
@@ -107,11 +131,15 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "960x600x256", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 64.0)
+        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 1920)
+        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 1200)
+        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 1920)
+        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 1200)
     #endif
 
     gen.add("desired_transmit_delay", int_t, 0, "desired_transmit_delay (ms)", 0, 0, 500)
 
-    if "sgm_cmv4000" in cfg.name or "sgm_AR0234" in cfg.name:
+    if "sgm_cmv4000" in cfg.name:
         gen.add("crop_mode", bool_t, 0, "Crop image to 2MP", False)
         gen.add("crop_offset", int_t, 0, "Crop Offset", 480, 0, 960)
     #endif
@@ -129,11 +157,6 @@ for cfg in sensorConfigList:
         gen.add("white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
         gen.add("white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
         gen.add("hdr_enable", bool_t, 0, "HDR Enable", False)
-        gen.add("roi_auto_exposure", bool_t, 0, "RoiAutoExposure", False)
-        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
-        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 2048)
-        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
-        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 2048)
     #endif
 
     if cfg.sgm:

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -31,6 +31,10 @@ sensorConfigList.append(SensorConfig(name="s27_sgm_AR0234",     sgm=True, imu=Fa
 for cfg in sensorConfigList:
     gen = ParameterGenerator()
 
+    roi_width = None
+    roi_height = None
+    auto_exposure_threshold = 0.75
+
     if cfg.name.find('sgm_cmv2000') != -1:
         res_enum = gen.enum([ gen.const("1024x272_64_disparities", str_t, "1024x272x64", "1024x272x64"),
                               gen.const("1024x272_128_disparities", str_t, "1024x272x128", "1024x272x128"),
@@ -47,10 +51,8 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x128", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
-        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
-        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 1088)
-        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
-        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 1088)
+        roi_width = 2048
+        roi_height = 1088
     elif cfg.name.find('sgm_cmv4000') != -1:
         res_enum = gen.enum([ gen.const("1024x512_64_disparities", str_t, "1024x512x64", "1024x512x64"),
                               gen.const("1024x512_128_disparities", str_t, "1024x512x128", "1024x512x128"),
@@ -67,30 +69,24 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x128", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
-        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
-        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 2048)
-        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
-        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 2048)
+        roi_width = 2048
+        roi_height = 2048
     elif cfg.name.find('bm_cmv2000') != -1:
         res_enum = gen.enum([ gen.const("1024x544_128_disparities", str_t, "1024x544x128", "1024x544x128"),
                               gen.const("2048x1088_No_disparities", str_t, "2048x1088x0", "2048x1088x0") ],
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x128", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
-        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
-        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 1088)
-        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
-        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 1088)
+        roi_width = 2048
+        roi_height = 1088
     elif cfg.name.find('bm_cmv4000') != -1:
         res_enum = gen.enum([ gen.const("1024x1024_128_disparities", str_t, "1024x1024x128", "1024x1024x128"),
                               gen.const("2048x2048_No_disparities", str_t, "2048x2048x0", "2048x2048x0") ],
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x128", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
-        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
-        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 2048)
-        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
-        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 2048)
+        roi_width = 2048
+        roi_height = 2048
     elif cfg.name.find('st21_sgm_vga_imu') != -1:
         res_enum = gen.enum([ gen.const("640x512_64_disparities", str_t, "640x512x64", "640x512x64"),
                               gen.const("640x512_128_disparities", str_t, "640x512x128", "640x512x128") ],
@@ -105,10 +101,8 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x0", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
-        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
-        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 1088)
-        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
-        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 1088)
+        roi_width = 2048
+        roi_height = 1088
     elif cfg.name.find('mono_cmv4000') != -1:
         res_enum = gen.enum([ gen.const("1024x512", str_t, "1024x512x0", "1024x512x0"),
                               gen.const("1024x1024", str_t, "1024x1024x0", "1024x1024x0"),
@@ -117,10 +111,8 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x0", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
-        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 2048)
-        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 2048)
-        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 2048)
-        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 2048)
+        roi_width = 2048
+        roi_height = 2048
     elif cfg.name.find('sgm_AR0234') != -1:
         res_enum = gen.enum([ gen.const("960x600_64_disparities", str_t, "960x600x64", "960x600x64"),
                               gen.const("960x600_128_disparities", str_t, "960x600x128", "960x600x128"),
@@ -131,10 +123,9 @@ for cfg in sensorConfigList:
                             "Available resolution settings")
         gen.add("resolution", str_t, 0, "sensor resolution", "960x600x256", edit_method=res_enum)
         gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 64.0)
-        gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, 1920)
-        gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, 1200)
-        gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, 1920)
-        gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, 1200)
+        roi_width = 1920
+        roi_height = 1200
+        auto_exposure_threshold = 0.95
     #endif
 
     gen.add("desired_transmit_delay", int_t, 0, "desired_transmit_delay (ms)", 0, 0, 500)
@@ -149,7 +140,7 @@ for cfg in sensorConfigList:
         gen.add("auto_exposure", bool_t, 0, "AutoExposure", True)
         gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.5, 0.0, 0.5);
         gen.add("auto_exposure_decay", int_t, 0, "AutoExposureDecay", 7, 0, 20)
-        gen.add("auto_exposure_thresh", double_t, 0, "AutoExposureThresh", 0.75, 0.0, 1.0)
+        gen.add("auto_exposure_thresh", double_t, 0, "AutoExposureThresh", auto_exposure_threshold, 0.0, 1.0)
         gen.add("exposure_time", double_t, 0, "Exposure", 0.025, 0, 0.5)
         gen.add("auto_white_balance", bool_t, 0, "AutoWhiteBalance", True)
         gen.add("auto_white_balance_decay", int_t, 0, "AutoWhiteBalanceDecay", 3, 0, 20)
@@ -157,7 +148,12 @@ for cfg in sensorConfigList:
         gen.add("white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
         gen.add("white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
         gen.add("hdr_enable", bool_t, 0, "HDR Enable", False)
-        gen.add("roi_auto_exposure", bool_t, 0, "RoiAutoExposure", False)
+        if roi_width is not None and roi_height is not None:
+            gen.add("roi_auto_exposure", bool_t, 0, "RoiAutoExposure", False)
+            gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, roi_width)
+            gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, roi_height)
+            gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, roi_width)
+            gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, roi_height)
     #endif
 
     if cfg.sgm:

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -144,6 +144,7 @@ private:
     bool motor_supported_ = false;
     bool crop_mode_changed_ = false;
     bool ptp_supported_ = false;
+    bool roi_supported_ = false;
 
     //
     // Cached value for the boarder clip. These are used to determine if we

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -384,6 +384,23 @@ template<class T> void Reconfigure::configureCamera(image::Config& cfg, const T&
     cfg.setAutoWhiteBalanceThresh(dyn.auto_white_balance_thresh);
     cfg.setHdr(dyn.hdr_enable);
 
+    if (dyn.roi_auto_exposure)
+    {
+        //
+        // Ensure the commanded ROI region is in the image
+
+        const int32_t x = std::max(0, std::min(dyn.roi_auto_exposure_x, width));
+        const int32_t y = std::max(0, std::min(dyn.roi_auto_exposure_y, height));
+
+        cfg.setAutoExposureRoi(x, y,
+                               std::max(0, std::min(dyn.roi_auto_exposure_width, width - x)),
+                               std::max(0, std::min(dyn.roi_auto_exposure_height, height - y)));
+    }
+    else
+    {
+        cfg.setAutoExposureRoi(0, 0, Roi_Full_Image, Roi_Full_Image);
+    }
+
     //
     // Apply, sensor enforces limits per setting.
 

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -392,14 +392,17 @@ template<class T> void Reconfigure::configureCamera(image::Config& cfg, const T&
     if (dyn.roi_auto_exposure) {
         if (roi_supported_) {
             //
-            // Ensure the commanded ROI region is in the image
+            // Ensure the commanded ROI region is in the full resolution image
 
-            const int32_t x = fmax(0, fmin(dyn.roi_auto_exposure_x, width));
-            const int32_t y = fmax(0, fmin(dyn.roi_auto_exposure_y, height));
+            const int32_t maxX = dyn.__getMax__().roi_auto_exposure_x;
+            const int32_t maxY = dyn.__getMax__().roi_auto_exposure_y;
+
+            const int32_t x = fmax(0, fmin(dyn.roi_auto_exposure_x, maxX));
+            const int32_t y = fmax(0, fmin(dyn.roi_auto_exposure_y, maxY));
 
             cfg.setAutoExposureRoi(x, y,
-                                   fmax(0, fmin(dyn.roi_auto_exposure_width, width - x)),
-                                   fmax(0, fmin(dyn.roi_auto_exposure_height, height - y)));
+                                   fmax(0, fmin(dyn.roi_auto_exposure_width, maxX - x)),
+                                   fmax(0, fmin(dyn.roi_auto_exposure_height, maxY - y)));
         } else {
             ROS_WARN("Reconfigure: ROI auto exposure is not supported with this firmware version");
         }


### PR DESCRIPTION
Enable ROI based auto exposure through dynamic reconfigure. This is supported on cameras with firmware >= 4.3