### PR TITLE
Add the show_roi stereo profile to dynamic reconfigure

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -154,8 +154,9 @@ for cfg in sensorConfigList:
 
         stereo_profile_enum = gen.enum([ gen.const("user_control", int_t, 0, ""),
                                          gen.const("detail_disparity", int_t, 1, ""),
-                                         gen.const("high_contrast", int_t, 2, "")],
-                                         "Trigger sources");
+                                         gen.const("high_contrast", int_t, 2, ""),
+                                         gen.const("show_rois", int_t, 3, "")],
+                                         "Stereo Profile");
         gen.add("stereo_profile", int_t, 0, "Stereo Profile", 0, edit_method=stereo_profile_enum)
 
     if cfg.imu:


### PR DESCRIPTION
Expose the `Show_ROIs` stereo profile in the ROS driver via dynamic reconfigure