### PR TITLE
Add support for the full resolution aux profile

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -197,6 +197,8 @@ for cfg in sensorConfigList:
         gen.add("detail_disparity_profile", bool_t, 0, "DetailDisparityProfile", False);
         gen.add("high_contrast_profile", bool_t, 0, "HighContrastProfile", False);
         gen.add("show_roi_profile", bool_t, 0, "ShowRoiProfile", False);
+        gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
+    #endif
 
     if cfg.imu:
         gen.add("imu_samples_per_message", int_t, 0, "ImuSamplesPerMessage", 30, 1, 300)

--- a/multisense_ros/include/multisense_ros/camera_utilities.h
+++ b/multisense_ros/include/multisense_ros/camera_utilities.h
@@ -48,6 +48,15 @@
 
 namespace multisense_ros {
 
+static constexpr size_t S30_AUX_CAM_WIDTH = 1920;
+static constexpr size_t S30_AUX_CAM_HEIGHT = 1188;
+
+struct OperatingResolutionT
+{
+    size_t width = 0;
+    size_t height = 0;
+};
+
 enum class BorderClip {NONE, RECTANGULAR, CIRCULAR};
 
 struct RectificationRemapT
@@ -165,13 +174,31 @@ public:
     double aux_T() const;
 
     ///
+    /// @brief Get the current main stereo pair operating resolution. This resolution applies for both the mono
+    ///        and rectified topics
+    ///
+    OperatingResolutionT operatingStereoResolution() const;
+
+    ///
+    /// @brief Get the current aux camera operating resolution. This resolution applies for just the mono topics. The
+    ///        Rectified aux topics match the operating stereo resolution
+    ///
+    OperatingResolutionT operatingAuxResolution() const;
+
+    ///
     /// @brief Determine if the Aux calibration is valid
     ///
     bool validAux() const;
 
     sensor_msgs::CameraInfo leftCameraInfo(const std::string& frame_id, const ros::Time& stamp) const;
     sensor_msgs::CameraInfo rightCameraInfo(const std::string& frame_id, const ros::Time& stamp) const;
-    sensor_msgs::CameraInfo auxCameraInfo(const std::string& frame_id, const ros::Time& stamp) const;
+    sensor_msgs::CameraInfo auxCameraInfo(const std::string& frame_id,
+                                            const ros::Time& stamp,
+                                            const OperatingResolutionT& resolution) const;
+    sensor_msgs::CameraInfo auxCameraInfo(const std::string& frame_id,
+                                          const ros::Time& stamp,
+                                          size_t width,
+                                          size_t height) const;
 
     std::shared_ptr<RectificationRemapT> leftRemap() const;
     std::shared_ptr<RectificationRemapT> rightRemap() const;

--- a/multisense_ros/include/multisense_ros/camera_utilities.h
+++ b/multisense_ros/include/multisense_ros/camera_utilities.h
@@ -193,8 +193,8 @@ public:
     sensor_msgs::CameraInfo leftCameraInfo(const std::string& frame_id, const ros::Time& stamp) const;
     sensor_msgs::CameraInfo rightCameraInfo(const std::string& frame_id, const ros::Time& stamp) const;
     sensor_msgs::CameraInfo auxCameraInfo(const std::string& frame_id,
-                                            const ros::Time& stamp,
-                                            const OperatingResolutionT& resolution) const;
+                                          const ros::Time& stamp,
+                                          const OperatingResolutionT& resolution) const;
     sensor_msgs::CameraInfo auxCameraInfo(const std::string& frame_id,
                                           const ros::Time& stamp,
                                           size_t width,

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -2124,7 +2124,7 @@ void Camera::publishAllCameraInfo()
         if (has_aux_camera_) {
 
             //
-            // The mono aux camera will operate a the native aux camera resolution. The rectifed cameras will match
+            // The mono aux camera will operate at the native aux camera resolution. The rectified cameras will match
             // the main stereo pair
 
             const auto stereoResolution = stereo_calibration_manager_->operatingStereoResolution();

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -1533,6 +1533,22 @@ void Camera::pointCloudCallback(const image::Header& header)
 
         cv::Mat rect_rgb_image(luma.height, luma.width, CV_8UC3, &(pointcloud_rect_color_buffer_[0]));
 
+        //
+        // If we are running in full-aux mode and 1/4 res mode resize the rectified aux image to match the
+        // disparity resolution
+
+        if (stereo_calibration_manager_->config().cameraProfile() == Full_Res_Aux_Cam &&
+            (header.width != luma.width || header.height != luma.height))
+        {
+            cv::Mat resized_rect_rgb_image;
+            cv::resize(rect_rgb_image,
+                       resized_rect_rgb_image,
+                       cv::Size{static_cast<int>(header.width), static_cast<int>(header.height)},
+                       0, 0, cv::INTER_AREA);
+
+            rect_rgb_image = std::move(resized_rect_rgb_image);
+        }
+
         rectified_color = std::move(rect_rgb_image);
     }
 

--- a/multisense_ros/src/camera_utilities.cpp
+++ b/multisense_ros/src/camera_utilities.cpp
@@ -43,8 +43,8 @@ namespace {
 
 struct ScaleT
 {
-    double x_scale = 0.0;
-    double y_scale = 0.0;
+    double x_scale = 1.0;
+    double y_scale = 1.0;
     double cx_offset = 0.0;
     double cy_offset = 0.0;
 };
@@ -263,7 +263,8 @@ StereoCalibrationManger::StereoCalibrationManger(const crl::multisense::image::C
     q_matrix_(makeQ(config_, calibration_, device_info_)),
     left_camera_info_(makeCameraInfo(config_, calibration_.left, compute_scale(config_, device_info_))),
     right_camera_info_(makeCameraInfo(config_, calibration_.right, compute_scale(config_, device_info_))),
-    aux_camera_info_(makeCameraInfo(config_, calibration_.aux, compute_scale(config_, device_info_))),
+    aux_camera_info_(makeCameraInfo(config_, calibration_.aux, config_.cameraProfile() == crl::multisense::Full_Res_Aux_Cam ?
+                                                               ScaleT{1., 1., 0., 0.} : compute_scale(config_, device_info_))),
     left_remap_(std::make_shared<RectificationRemapT>(makeRectificationRemap(config_, calibration_.left, device_info_))),
     right_remap_(std::make_shared<RectificationRemapT>(makeRectificationRemap(config_, calibration_.right, device_info_)))
 {
@@ -285,10 +286,10 @@ void StereoCalibrationManger::updateConfig(const crl::multisense::image::Config&
     auto left_camera_info = makeCameraInfo(config, calibration_.left, compute_scale(config_, device_info_));
     auto right_camera_info = makeCameraInfo(config, calibration_.right, compute_scale(config_, device_info_));
 
-    const ScaleT aux_scale = config_.cameraProfile() == crl::multisense::Full_Res_Aux_Cam ?
+    const ScaleT aux_scale = config.cameraProfile() == crl::multisense::Full_Res_Aux_Cam ?
                              ScaleT{1., 1., 0., 0.} : compute_scale(config_, device_info_);
 
-    auto aux_camera_info_ = makeCameraInfo(config, calibration_.aux, aux_scale);
+    auto aux_camera_info = makeCameraInfo(config, calibration_.aux, aux_scale);
     auto left_remap = std::make_shared<RectificationRemapT>(makeRectificationRemap(config, calibration_.left, device_info_));
     auto right_remap = std::make_shared<RectificationRemapT>(makeRectificationRemap(config, calibration_.right, device_info_));
 
@@ -298,6 +299,7 @@ void StereoCalibrationManger::updateConfig(const crl::multisense::image::Config&
     q_matrix_ = std::move(q_matrix);
     left_camera_info_ = std::move(left_camera_info);
     right_camera_info_ = std::move(right_camera_info);
+    aux_camera_info_ = std::move(aux_camera_info);
     left_remap_ = left_remap;
     right_remap_ = right_remap;
 }

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -696,6 +696,7 @@ template<class T> void Reconfigure::configureStereoProfile(crl::multisense::imag
     profile |= (dyn.detail_disparity_profile ? crl::multisense::Detail_Disparity : profile);
     profile |= (dyn.high_contrast_profile ? crl::multisense::High_Contrast : profile);
     profile |= (dyn.show_roi_profile ? crl::multisense::Show_ROIs : profile);
+    profile |= (dyn.full_res_aux_profile ? crl::multisense::Full_Res_Aux_Cam : profile);
 
     cfg.setCameraProfile(profile);
 }


### PR DESCRIPTION
Add support for the full resolution aux camera profile. This mode allows the main stereo pair to run in binned 1/4 resolution while the aux camera operates in full resolution. We need to make sure to resize the aux image before creating color pointclouds, and make sure we apply the appropriate scale to the aux camera info. 