### PR TITLE
Add MultiSense device info and status diagnostics.

### DIFF
--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -40,6 +40,8 @@
 
 #include <ros/ros.h>
 
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/publisher.h>
 #include <image_geometry/stereo_camera_model.h>
 #include <image_transport/image_transport.h>
 #include <image_transport/camera_publisher.h>
@@ -47,7 +49,6 @@
 #include <stereo_msgs/DisparityImage.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <tf2_ros/static_transform_broadcaster.h>
-
 
 #include <multisense_lib/MultiSenseChannel.hh>
 #include <multisense_ros/RawCamData.h>
@@ -328,6 +329,16 @@ private:
     // Has a 3rd aux color camera
 
     bool has_aux_camera_ = false;
+
+
+    //
+    // Diagnostics
+    diagnostic_updater::Updater diagnostic_updater_;
+    void deviceInfoDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    void deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+
+    void diagnosticTimerCallback(const ros::TimerEvent &);
+    ros::Timer diagnostic_trigger_;
 };
 
 }

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -330,7 +330,6 @@ private:
 
     bool has_aux_camera_ = false;
 
-
     //
     // Diagnostics
     diagnostic_updater::Updater diagnostic_updater_;

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -2162,8 +2162,7 @@ void Camera::deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper&
 {
         crl::multisense::system::StatusMessage statusMessage;
 
-        if (crl::multisense::Status_Ok == driver_->getDeviceStatus(statusMessage))
-        {
+        if (crl::multisense::Status_Ok == driver_->getDeviceStatus(statusMessage)) {
             stat.add("uptime",              ros::Time(statusMessage.uptime));
             stat.add("system",              statusMessage.systemOk);
             stat.add("laser",               statusMessage.laserOk);
@@ -2182,9 +2181,7 @@ void Camera::deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper&
             stat.add("logic power",         statusMessage.logicPower);
             stat.add("imager power",        statusMessage.imagerPower);
             stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "MultiSense Status: OK");
-        }
-        else
-        {
+        } else {
             stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "MultiSense Status: ERROR - Unable to retrieve status");
         }
 }

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -726,6 +726,13 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
     if (NULL != pcColorFrameSyncEnvStringP) {
         ROS_INFO("color point cloud frame sync is disabled");
     }
+
+    //
+    // Diagnostics
+    diagnostic_updater_.setHardwareID(device_info_.name + " " + std::to_string(device_info_.hardwareRevision));
+    diagnostic_updater_.add("device_status", this, &Camera::deviceInfoDiagnostic);
+    diagnostic_updater_.add("device_status", this, &Camera::deviceStatusDiagnostic);
+    diagnostic_trigger_ = device_nh_.createTimer(ros::Duration(1), &Camera::diagnosticTimerCallback, this);
 }
 
 Camera::~Camera()
@@ -2107,6 +2114,84 @@ void Camera::publishAllCameraInfo()
             aux_rgb_rect_cam_info_pub_.publish(stereo_calibration_manager_->auxCameraInfo(frame_id_rectified_aux_, stamp));
         }
     }
+}
+
+void Camera::deviceInfoDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat)
+{
+    stat.add("device name",               device_info_.name);
+    stat.add("build date",                device_info_.buildDate);
+    stat.add("serial number",             device_info_.serialNumber);
+    stat.add("device revision",           device_info_.hardwareRevision);
+
+    for(const auto &pcb : device_info_.pcbs) {
+        stat.add("pcb: " + pcb.name, pcb.revision);
+    }
+
+    stat.add("imager name",               device_info_.imagerName);
+    stat.add("imager type",               device_info_.imagerType);
+    stat.add("imager width",              device_info_.imagerWidth);
+    stat.add("imager height",             device_info_.imagerHeight);
+
+    stat.add("lens name",                 device_info_.lensName);
+    stat.add("lens type",                 device_info_.lensType);
+    stat.add("nominal baseline",          device_info_.nominalBaseline);
+    stat.add("nominal focal length",      device_info_.nominalFocalLength);
+    stat.add("nominal relative aperture", device_info_.nominalRelativeAperture);
+
+    stat.add("lighting type",             device_info_.lightingType);
+    stat.add("number of lights",          device_info_.numberOfLights);
+
+    stat.add("laser name",                device_info_.laserName);
+    stat.add("laser type",                device_info_.laserType);
+
+    stat.add("motor name",                device_info_.motorName);
+    stat.add("motor type",                device_info_.motorType);
+    stat.add("motor gear reduction",      device_info_.motorGearReduction);
+
+    stat.add("api build date",            version_info_.apiBuildDate);
+    stat.add("api version",               version_info_.apiVersion);
+    stat.add("firmware build date",       version_info_.sensorFirmwareBuildDate);
+    stat.add("firmware version",          version_info_.sensorFirmwareVersion);
+    stat.add("bitstream version",         version_info_.sensorHardwareVersion);
+    stat.add("bitstream magic",           version_info_.sensorHardwareMagic);
+    stat.add("fpga dna",                  version_info_.sensorFpgaDna);
+    stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "MultiSense Device Info");
+}
+
+void Camera::deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat)
+{
+        crl::multisense::system::StatusMessage statusMessage;
+
+        if (crl::multisense::Status_Ok == driver_->getDeviceStatus(statusMessage))
+        {
+            stat.add("uptime",              ros::Time(statusMessage.uptime));
+            stat.add("system",              statusMessage.systemOk);
+            stat.add("laser",               statusMessage.laserOk);
+            stat.add("laser motor",         statusMessage.laserMotorOk);
+            stat.add("cameras",             statusMessage.camerasOk);
+            stat.add("imu",                 statusMessage.imuOk);
+            stat.add("external leds",       statusMessage.externalLedsOk);
+            stat.add("processing pipeline", statusMessage.processingPipelineOk);
+            stat.add("power supply temp",   statusMessage.powerSupplyTemperature);
+            stat.add("fpga temp",           statusMessage.fpgaTemperature);
+            stat.add("left imager temp",    statusMessage.leftImagerTemperature);
+            stat.add("right imager temp",   statusMessage.rightImagerTemperature);
+            stat.add("input voltage",       statusMessage.inputVoltage);
+            stat.add("input current",       statusMessage.inputCurrent);
+            stat.add("fpga power",          statusMessage.fpgaPower);
+            stat.add("logic power",         statusMessage.logicPower);
+            stat.add("imager power",        statusMessage.imagerPower);
+            stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "MultiSense Status: OK");
+        }
+        else
+        {
+            stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "MultiSense Status: ERROR - Unable to retrieve status");
+        }
+}
+
+void Camera::diagnosticTimerCallback(const ros::TimerEvent&)
+{
+    diagnostic_updater_.update();
 }
 
 void Camera::stop()


### PR DESCRIPTION
Summary: Add MultiSense device info and status diagnostics. The diagnostic updater will update at 1 Hz. Device info and status will be published as a DiagnosticStatus message. The hardware id is set to device name + device hardware revision.  

Test plan: Test with MultiSense S27.