### PR TITLE
fix diangostic updater dependency bug

### DIFF
--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -31,7 +31,8 @@ find_package(catkin REQUIRED COMPONENTS roscpp
                                         cv_bridge
                                         dynamic_reconfigure
                                         image_geometry
-                                        message_generation)
+                                        message_generation
+                                        diagnostic_updater)
 
 find_library(LIBTURBOJPEG_LIBRARIES NAMES "libturbojpeg.so.0" "libturbojpeg.so.1")
 
@@ -70,6 +71,7 @@ catkin_package(INCLUDE_DIRS   include
                               image_transport
                               message_runtime
                               message_generation
+                              diagnostic_updater
                LIBRARIES      ${PROJECT_NAME})
 
 include_directories(include

--- a/multisense_ros/package.xml
+++ b/multisense_ros/package.xml
@@ -32,6 +32,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>libturbojpeg</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>diagnostic_updater</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
@@ -53,6 +54,7 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>libturbojpeg</run_depend>
   <run_depend>eigen</run_depend>
+  <run_depend>diagnostic_updater</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Fixes a bug where multisense_ros will not build when all of its dependencies (ROS, cv_bridge, geometry2, image_common, diagnostics) are built from source.

Signed-off-by: John Atkinson <jatkinson@carnegierobotics.com>