### PR TITLE
Support dynamic extrinsics parameter updates

### DIFF
--- a/multisense_bringup/multisense.launch
+++ b/multisense_bringup/multisense.launch
@@ -14,7 +14,7 @@
   <!-- Robot state publisher -->
   <group if = "$(arg launch_robot_state_publisher)">
     <param name="robot_description"
-          command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg sensor)/standalone.urdf.xacro' name:=$(arg namespace)"/>
+          command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisenseS27/standalone.urdf.xacro' name:=$(arg namespace)"/>
     <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg nodes_prefix)_state_publisher">
       <param name="publish_frequency" type="double" value="50.0" />
       <remap from="joint_states" to="/$(arg namespace)/joint_states" />

--- a/multisense_bringup/multisense.launch
+++ b/multisense_bringup/multisense.launch
@@ -14,7 +14,7 @@
   <!-- Robot state publisher -->
   <group if = "$(arg launch_robot_state_publisher)">
     <param name="robot_description"
-          command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisenseS27/standalone.urdf.xacro' name:=$(arg namespace)"/>
+          command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg sensor)/standalone.urdf.xacro' name:=$(arg namespace)"/>
     <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg nodes_prefix)_state_publisher">
       <param name="publish_frequency" type="double" value="50.0" />
       <remap from="joint_states" to="/$(arg namespace)/joint_states" />

--- a/multisense_bringup/rviz_config.rviz
+++ b/multisense_bringup/rviz_config.rviz
@@ -295,7 +295,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: multisense/head
+    Fixed Frame: multisense/origin
     Frame Rate: 30
   Name: root
   Tools:

--- a/multisense_bringup/rviz_config.rviz
+++ b/multisense_bringup/rviz_config.rviz
@@ -42,7 +42,7 @@ Visualization Manager:
         X: 0
         Y: 0
         Z: 0
-      Plane: XY
+      Plane: XZ
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
       Value: true

--- a/multisense_description/urdf/multisenseBCAM/multisenseBCAM.urdf.xacro
+++ b/multisense_description/urdf/multisenseBCAM/multisenseBCAM.urdf.xacro
@@ -24,11 +24,11 @@
 
         <link name="${name}/left_camera_frame"/>
 
-
-        <joint name="${name}/left_camera_optical_joint" type="fixed">
-            <origin xyz="0 0 0" rpy="-1.57079632679 0.0 -1.57079632679"/>
-            <parent link="${name}/left_camera_frame"/>
-            <child link="${name}/left_camera_optical_frame"/>
+        <!-- Left camera optical frame is treated as the camera origin -->
+        <joint name="${name}/head_optical_joint" type="fixed">
+            <origin xyz="0 0 -0.03" rpy="0.0 -1.57079632679 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
         </joint>
 
         <link name="${name}/left_camera_optical_frame"/>

--- a/multisense_description/urdf/multisenseS21/multisenseS21.urdf.xacro
+++ b/multisense_description/urdf/multisenseS21/multisenseS21.urdf.xacro
@@ -2,17 +2,6 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
     <xacro:macro name="multisenseS21" params="name">
 
-        <link name="${name}/left_camera_optical_frame"/>
-
-        <!-- Note the origin of model is 37.3854mm from the rear mounting plane
-             in the x axis -->
-
-        <joint name="${name}/head_joint" type="fixed">
-            <origin xyz="0.105 0 -0.0052046" rpy="0.0 -1.57079632679 1.57079632679"/>
-            <parent link="${name}/left_camera_optical_frame"/>
-            <child link="${name}/head"/>
-        </joint>
-
         <link name="${name}/head">
             <visual>
                 <origin xyz="0 0 0" rpy="1.57079632679 0 1.57079632679" />
@@ -24,6 +13,18 @@
                 </material>
             </visual>
         </link>
+
+        <!-- Note the origin of model is 37.3854mm from the rear mounting plane
+             in the x axis -->
+
+        <!-- Left camera optical frame is treated as the camera origin -->
+        <joint name="${name}/head_joint" type="fixed">
+            <origin xyz="0.105 0 -0.0052046" rpy="0.0 -1.57079632679 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
+        </joint>
+
+        <link name="${name}/left_camera_optical_frame"/>
 
         <joint name="${name}/top_left_rear_mount_joint" type="fixed">
             <origin xyz="-0.0373854 0.1 0.014" rpy="0 0 3.14159"/>

--- a/multisense_description/urdf/multisenseS21/multisenseS21.urdf.xacro
+++ b/multisense_description/urdf/multisenseS21/multisenseS21.urdf.xacro
@@ -2,6 +2,17 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
     <xacro:macro name="multisenseS21" params="name">
 
+        <link name="${name}/left_camera_optical_frame"/>
+
+        <!-- Note the origin of model is 37.3854mm from the rear mounting plane
+             in the x axis -->
+
+        <joint name="${name}/head_joint" type="fixed">
+            <origin xyz="0.105 0 -0.0052046" rpy="0.0 -1.57079632679 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
+        </joint>
+
         <link name="${name}/head">
             <visual>
                 <origin xyz="0 0 0" rpy="1.57079632679 0 1.57079632679" />
@@ -13,17 +24,6 @@
                 </material>
             </visual>
         </link>
-
-        <!-- Note the origin of model is 37.3854mm from the rear mounting plane
-             in the x axis -->
-
-        <joint name="${name}/left_camera_joint" type="fixed">
-            <origin xyz="0.0052046 0.105 0" rpy="-1.57079632679 0.0 -1.57079632679"/>
-            <parent link="${name}/head"/>
-            <child link="${name}/left_camera_optical_frame"/>
-        </joint>
-
-        <link name="${name}/left_camera_optical_frame"/>
 
         <joint name="${name}/top_left_rear_mount_joint" type="fixed">
             <origin xyz="-0.0373854 0.1 0.014" rpy="0 0 3.14159"/>

--- a/multisense_description/urdf/multisenseS27/multisenseS27.urdf.xacro
+++ b/multisense_description/urdf/multisenseS27/multisenseS27.urdf.xacro
@@ -14,10 +14,11 @@
             </visual>
         </link>
 
-        <joint name="${name}/left_camera_joint" type="fixed">
-            <origin xyz="0.08 0.312 0.037" rpy="-1.989 0.0 -1.57079632679"/>
-            <parent link="${name}/head"/>
-            <child link="${name}/left_camera_optical_frame"/>
+        <!-- Left camera optical frame is treated as the camera origin -->
+        <joint name="${name}/head_joint" type="fixed">
+            <origin xyz="0.312 0.06630059527 -0.05807952365" rpy="0.0 -1.989 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
         </joint>
 
         <link name="${name}/left_camera_optical_frame"/>

--- a/multisense_description/urdf/multisenseS7/multisenseS7.urdf.xacro
+++ b/multisense_description/urdf/multisenseS7/multisenseS7.urdf.xacro
@@ -14,13 +14,14 @@
             </visual>
         </link>
 
-        <joint name="${name}/left_camera_joint" type="fixed">
-            <origin xyz="0.052 0.035 0.0" rpy="-1.57079632679 0.0 -1.57079632679"/>
-            <parent link="${name}/head"/>
-            <child link="${name}/left_camera_opticial_frame"/>
+        <!-- Left camera optical frame is treated as the camera origin -->
+        <joint name="${name}/head_joint" type="fixed">
+            <origin xyz="0.035 0.0 -0.052" rpy="0.0 -1.57079632679 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
         </joint>
 
-        <link name="${name}/left_camera_opticial_frame"/>
+        <link name="${name}/left_camera_optical_frame"/>
 
         <joint name="${name}/accel_joint" type="fixed">
             <origin xyz="0.047 0.0302 -0.00075" rpy="0.0 1.57079632679 0.0"/>

--- a/multisense_description/urdf/multisenseS7S/multisenseS7S.urdf.xacro
+++ b/multisense_description/urdf/multisenseS7S/multisenseS7S.urdf.xacro
@@ -14,10 +14,11 @@
             </visual>
         </link>
 
-        <joint name="${name}/left_camera_joint" type="fixed">
-            <origin xyz="0.03 0.035 0.0" rpy="-1.57079632679 0.0 -1.57079632679"/>
-            <parent link="${name}/head"/>
-            <child link="${name}/left_camera_optical_frame"/>
+        <!-- Left camera optical frame is treated as the camera origin -->
+        <joint name="${name}/head_joint" type="fixed">
+            <origin xyz="0.035 0.0 -0.03" rpy="0.0 -1.57079632679 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
         </joint>
 
         <link name="${name}/left_camera_optical_frame"/>

--- a/multisense_description/urdf/multisenseSL/multisenseSL.urdf.xacro
+++ b/multisense_description/urdf/multisenseSL/multisenseSL.urdf.xacro
@@ -76,12 +76,15 @@
       <child link="${name}/head_hokuyo_frame"/>
     </joint>
 
-    <!-- Stereo Camera -->
-    <joint name="${name}/left_camera_frame_joint" type="fixed">
+    <!--
+      Stereo Camera
+      Note that the left camera optical frame is treated as the camera origin
+      -->
+    <joint name="${name}/head_joint" type="fixed">
       <!-- optical frame collocated with tilting DOF -->
-      <origin xyz="0.0 0.035 -0.002" rpy="-1.57079632679 0.0 -1.57079632679" />
-      <parent link="${name}/head"/>
-      <child link="${name}/left_camera_optical_frame"/>
+      <origin xyz="0.035 -0.002 0.0" rpy="0.0 -1.57079632679 1.57079632679" />
+      <parent link="${name}/left_camera_optical_frame"/>
+      <child link="${name}/head"/>
     </joint>
 
     <link name="${name}/left_camera_optical_frame" />

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -267,6 +267,13 @@ for cfg in sensorConfigList:
 
     gen.add("max_point_cloud_range", double_t, 0, "max point cloud range", 15.0, 0.0, 100.0)
 
+    gen.add("extrinsics_position_x_m", double_t, 0, "Extrinsics x value (m)", 0.0, -100.0, 100.0)
+    gen.add("extrinsics_position_y_m", double_t, 0, "Extrinsics y value (m)", 0.0, -100.0, 100.0)
+    gen.add("extrinsics_position_z_m", double_t, 0, "Extrinsics z value (m)", 0.0, -100.0, 100.0)
+    gen.add("extrinsics_rotation_x_deg", double_t, 0, "Extrinsics angle axis rotation x (deg)", 0.0, -180.0, 180.0)
+    gen.add("extrinsics_rotation_y_deg", double_t, 0, "Extrinsics angle axis rotation y (deg)", 0.0, -180.0, 180.0)
+    gen.add("extrinsics_rotation_z_deg", double_t, 0, "Extrinsics angle axis rotation z (deg)", 0.0, -180.0, 180.0)
+
     gen.generate(PACKAGE, cfg.name, cfg.name)
 #endfor
 

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -197,6 +197,7 @@ for cfg in sensorConfigList:
         gen.add("detail_disparity_profile", bool_t, 0, "DetailDisparityProfile", False);
         gen.add("high_contrast_profile", bool_t, 0, "HighContrastProfile", False);
         gen.add("show_roi_profile", bool_t, 0, "ShowRoiProfile", False);
+        gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
         gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
     #endif
 

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -285,12 +285,12 @@ for cfg in sensorConfigList:
 
     gen.add("max_point_cloud_range", double_t, 0, "max point cloud range", 15.0, 0.0, 100.0)
 
-    gen.add("extrinsics_position_x_m", double_t, 0, "Extrinsics x value (m)", 0.0, -100.0, 100.0)
-    gen.add("extrinsics_position_y_m", double_t, 0, "Extrinsics y value (m)", 0.0, -100.0, 100.0)
-    gen.add("extrinsics_position_z_m", double_t, 0, "Extrinsics z value (m)", 0.0, -100.0, 100.0)
-    gen.add("extrinsics_rotation_x_deg", double_t, 0, "Extrinsics angle axis rotation x (deg)", 0.0, -180.0, 180.0)
-    gen.add("extrinsics_rotation_y_deg", double_t, 0, "Extrinsics angle axis rotation y (deg)", 0.0, -180.0, 180.0)
-    gen.add("extrinsics_rotation_z_deg", double_t, 0, "Extrinsics angle axis rotation z (deg)", 0.0, -180.0, 180.0)
+    gen.add("origin_from_camera_position_x_m", double_t, 0, "Origin from camera extrinsics transform x value (m)", 0.0, -100.0, 100.0)
+    gen.add("origin_from_camera_position_y_m", double_t, 0, "Origin from camera extrinsics transform y value (m)", 0.0, -100.0, 100.0)
+    gen.add("origin_from_camera_position_z_m", double_t, 0, "Origin from camera extrinsics transform z value (m)", 0.0, -100.0, 100.0)
+    gen.add("origin_from_camera_rotation_x_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation x (deg)", 0.0, -180.0, 180.0)
+    gen.add("origin_from_camera_rotation_y_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation y (deg)", 0.0, -180.0, 180.0)
+    gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
 
     gen.generate(PACKAGE, cfg.name, cfg.name)
 #endfor

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -81,6 +81,8 @@ public:
 
     void maxPointCloudRangeChanged(double range);
 
+    void extrinsicsChanged(crl::multisense::system::ExternalCalibration extrinsics);
+
 private:
     //
     // Node names
@@ -308,6 +310,11 @@ private:
     // Max distance from the camera for a point to be considered valid
 
     double pointcloud_max_range_ = 15.0;
+
+    //
+    // Extrinsics to modify pointcloud
+
+    Eigen::Matrix4d extrinsics_;
 
     //
     // Histogram tracking

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -96,6 +96,8 @@ private:
     //
     // Frames
 
+    static constexpr char ORIGIN_FRAME[] = "/origin";
+    static constexpr char HEAD_FRAME[] = "/head";
     static constexpr char LEFT_CAMERA_FRAME[] = "/left_camera_frame";
     static constexpr char LEFT_RECTIFIED_FRAME[] = "/left_camera_optical_frame";
     static constexpr char RIGHT_CAMERA_FRAME[] = "/right_camera_frame";
@@ -290,6 +292,8 @@ private:
     //
     // The frame IDs
 
+    const std::string frame_id_origin_;
+    const std::string frame_id_head_;
     const std::string frame_id_left_;
     const std::string frame_id_right_;
     const std::string frame_id_aux_;
@@ -310,11 +314,6 @@ private:
     // Max distance from the camera for a point to be considered valid
 
     double pointcloud_max_range_ = 15.0;
-
-    //
-    // Extrinsics to modify pointcloud
-
-    Eigen::Matrix4d extrinsics_;
 
     //
     // Histogram tracking

--- a/multisense_ros/include/multisense_ros/camera_utilities.h
+++ b/multisense_ros/include/multisense_ros/camera_utilities.h
@@ -38,6 +38,8 @@
 #include <mutex>
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
+
 #include <opencv2/opencv.hpp>
 
 #include <ros/ros.h>

--- a/multisense_ros/include/multisense_ros/ground_surface_utilities.h
+++ b/multisense_ros/include/multisense_ros/ground_surface_utilities.h
@@ -66,8 +66,6 @@ sensor_msgs::PointCloud2 eigenToPointcloud(
 /// @param xzCellSize Size of the X,Z plane containing the spline fit in meters
 /// @param xzLimit X,Z limit to the spline fitting area in meters
 /// @param minMaxAzimuthAngle Min and max limit to the spline fitting angle in radians, for visualization purposes
-/// @param extrinsics Camera extrinsics that were used in the ground surface fitting operation
-///                   Order of parameters is x, y, z in meters then rz, ry, rz in radians
 /// @param quadraticParams parameters for the quadratic data transformation prior to spline fitting
 /// @param baseline Stereo camera baseline in meters
 /// @return Eigen representation of spline pointcloud at regularly sample x/z intervals
@@ -78,7 +76,6 @@ std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertS
     const float* xzCellSize,
     const float* xzLimit,
     const float* minMaxAzimuthAngle,
-    const float* extrinsics,
     const float* quadraticParams,
     const float baseline);
 

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -60,7 +60,8 @@ public:
     Reconfigure(crl::multisense::Channel* driver,
                 std::function<void (crl::multisense::image::Config)> resolutionChangeCallback,
                 std::function<void (BorderClip, double)> borderClipChangeCallback,
-                std::function<void (double)> maxPointCloudRangeCallback);
+                std::function<void (double)> maxPointCloudRangeCallback,
+                std::function<void (crl::multisense::system::ExternalCalibration)> extrinsicsCallback);
 
     ~Reconfigure();
 
@@ -99,6 +100,7 @@ private:
     template<class T> void configurePointCloudRange(const T& dyn);
     template<class T> void configurePtp(const T& dyn);
     template<class T> void configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn);
+    template<class T> void configureExtrinsics(const T& dyn);
 
     //
     // CRL sensor API
@@ -164,6 +166,11 @@ private:
     // Max point cloud range callback
 
     std::function<void (double)> max_point_cloud_range_callback_;
+
+    //
+    // Extrinsics callback to modify pointcloud
+
+    std::function<void (crl::multisense::system::ExternalCalibration)> extrinsics_callback_;
 };
 
 } // multisense_ros

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -2048,7 +2048,6 @@ void Camera::groundSurfaceSplineCallback(const ground_surface::Header& header)
         header.xzCellSize,
         header.xzLimit,
         minMaxAzimuthAngle,
-        header.extrinsics,
         header.quadraticParams,
         config.tx()
     );

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -802,7 +802,7 @@ void Camera::extrinsicsChanged(crl::multisense::system::ExternalCalibration extr
     tf2::Transform multisense_head_T_origin{tf2_rot, tf2::Vector3{extrinsics.x, extrinsics.y, extrinsics.z}};
     extrinsic_transforms_[0].header.stamp = ros::Time::now();
     extrinsic_transforms_[0].header.frame_id = frame_id_origin_;
-    extrinsic_transforms_[0].child_frame_id = frame_id_head_;
+    extrinsic_transforms_[0].child_frame_id = frame_id_rectified_left_;
     extrinsic_transforms_[0].transform = tf2::toMsg(multisense_head_T_origin);
 
     static_tf_broadcaster_.sendTransform(extrinsic_transforms_);

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -1537,7 +1537,6 @@ void Camera::pointCloudCallback(const image::Header& header)
         color_organized_point_cloud_.row_step = header.width * color_organized_point_cloud_.point_step;
     }
 
-    // Precompute transform matrix
     const Eigen::Matrix4d Q = stereo_calibration_manager_->Q();
 
     const Eigen::Vector3f invalid_point(std::numeric_limits<float>::quiet_NaN(),

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -1538,7 +1538,7 @@ void Camera::pointCloudCallback(const image::Header& header)
     }
 
     // Precompute transform matrix
-    const Eigen::Matrix4d tf_matrix = stereo_calibration_manager_->Q();
+    const Eigen::Matrix4d Q = stereo_calibration_manager_->Q();
 
     const Eigen::Vector3f invalid_point(std::numeric_limits<float>::quiet_NaN(),
                                         std::numeric_limits<float>::quiet_NaN(),
@@ -1666,7 +1666,7 @@ void Camera::pointCloudCallback(const image::Header& header)
                 continue;
             }
 
-            const Eigen::Vector3f point = ((tf_matrix * Eigen::Vector4d(static_cast<double>(x),
+            const Eigen::Vector3f point = ((Q * Eigen::Vector4d(static_cast<double>(x),
                                                                 static_cast<double>(y),
                                                                 disparity,
                                                                 1.0)).hnormalized()).cast<float>();

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -785,9 +785,9 @@ void Camera::extrinsicsChanged(crl::multisense::system::ExternalCalibration extr
     extrinsics_mat(2, 3) = static_cast<double>(extrinsics.z);
     extrinsics_mat(3, 3) = static_cast<double>(1.0);
     Eigen::Matrix<double, 3, 3> rot =
-        (Eigen::AngleAxis<double>(extrinsics.roll, Eigen::Matrix<double, 3, 1>(0, 0, 1))
+        (Eigen::AngleAxis<double>(extrinsics.yaw, Eigen::Matrix<double, 3, 1>(0, 0, 1))
         * Eigen::AngleAxis<double>(extrinsics.pitch, Eigen::Matrix<double, 3, 1>(0, 1, 0))
-        * Eigen::AngleAxis<double>(extrinsics.yaw, Eigen::Matrix<double, 3, 1>(1, 0, 0))).matrix();
+        * Eigen::AngleAxis<double>(extrinsics.roll, Eigen::Matrix<double, 3, 1>(1, 0, 0))).matrix();
     extrinsics_mat.block(0, 0, 3, 3) = rot;
 
     // Assign to class member

--- a/multisense_ros/src/ground_surface_utilities.cpp
+++ b/multisense_ros/src/ground_surface_utilities.cpp
@@ -209,30 +209,12 @@ std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertS
     const float* xzCellSize,
     const float* xzLimit,
     const float* minMaxAzimuthAngle,
-    const float* extrinsics,
+    const float*,
     const float* quadraticParams,
     const float baseline)
 {
     static constexpr double drawResolution = 0.1;
     static const auto basisArray = generateBasisArray();
-
-    // Generate extrinsics matrix
-    Eigen::Matrix<float, 4, 4> extrinsicsMat;
-    {
-        extrinsicsMat.setZero();
-        extrinsicsMat(0, 3) = extrinsics[0];
-        extrinsicsMat(1, 3) = extrinsics[1];
-        extrinsicsMat(2, 3) = extrinsics[2];
-        extrinsicsMat(3, 3) = static_cast<float>(1.0);
-        Eigen::Matrix<float, 3, 3> rot =
-            (Eigen::AngleAxis<float>(extrinsics[5], Eigen::Matrix<float, 3, 1>(0, 0, 1))
-            * Eigen::AngleAxis<float>(extrinsics[4], Eigen::Matrix<float, 3, 1>(0, 1, 0))
-            * Eigen::AngleAxis<float>(extrinsics[3], Eigen::Matrix<float, 3, 1>(1, 0, 0))).matrix();
-        extrinsicsMat.block(0, 0, 3, 3) = rot;
-    }
-
-    // Precompute extrinsics inverse
-    const auto extrinsicsInverse = extrinsicsMat.inverse();
 
     // Get boundaries of valid spline area
     const auto minX = xzCellOrigin[0] + xzCellSize[0];
@@ -270,7 +252,7 @@ std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertS
                            + computeQuadraticSurface(x, z, quadraticParams);
 
             auto splinePoint = Eigen::Vector3f(x, y, z);
-            auto transformedSplinePoint = extrinsicsInverse * splinePoint.homogeneous();
+            auto transformedSplinePoint = splinePoint.homogeneous();
             points.emplace_back(transformedSplinePoint.hnormalized());
         }
     }

--- a/multisense_ros/src/ground_surface_utilities.cpp
+++ b/multisense_ros/src/ground_surface_utilities.cpp
@@ -209,7 +209,6 @@ std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertS
     const float* xzCellSize,
     const float* xzLimit,
     const float* minMaxAzimuthAngle,
-    const float*,
     const float* quadraticParams,
     const float baseline)
 {

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -776,6 +776,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureCamera(cfg, dyn);                              \
         configureLeds(dyn);                                     \
         configureImu(dyn);                                      \
+        configureExtrinsics(dyn);                               \
     } while(0)
 
 #define SL_SGM_IMU()  do {                                      \

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -717,14 +717,14 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
     // Update calibration on camera via libmultisense
     crl::multisense::system::ExternalCalibration calibration;
 
-    calibration.x = dyn.extrinsics_position_x_m;
-    calibration.y = dyn.extrinsics_position_y_m;
-    calibration.z = dyn.extrinsics_position_z_m;
+    calibration.x = dyn.origin_from_camera_position_x_m;
+    calibration.y = dyn.origin_from_camera_position_y_m;
+    calibration.z = dyn.origin_from_camera_position_z_m;
 
     constexpr float deg_to_rad = M_PI / 180.0f;
-    calibration.roll = dyn.extrinsics_rotation_x_deg * deg_to_rad;
-    calibration.pitch = dyn.extrinsics_rotation_y_deg * deg_to_rad;
-    calibration.yaw = dyn.extrinsics_rotation_z_deg * deg_to_rad;
+    calibration.roll = dyn.origin_from_camera_rotation_x_deg * deg_to_rad;
+    calibration.pitch = dyn.origin_from_camera_rotation_y_deg * deg_to_rad;
+    calibration.yaw = dyn.origin_from_camera_rotation_z_deg * deg_to_rad;
 
     // Update extrinsics on camera
     Status status = driver_->setExternalCalibration(calibration);
@@ -840,6 +840,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureLeds(dyn);                                     \
         configurePtp(dyn);                                      \
         configurePointCloudRange(dyn);                          \
+        configureExtrinsics(dyn);                               \
     } while(0)
 
 

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -691,11 +691,11 @@ template<class T> void Reconfigure::configurePtp(const T& dyn)
 
 template<class T> void Reconfigure::configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn)
 {
-
     crl::multisense::CameraProfile profile = crl::multisense::User_Control;
     profile |= (dyn.detail_disparity_profile ? crl::multisense::Detail_Disparity : profile);
     profile |= (dyn.high_contrast_profile ? crl::multisense::High_Contrast : profile);
     profile |= (dyn.show_roi_profile ? crl::multisense::Show_ROIs : profile);
+    profile |= (dyn.ground_surface_profile ? crl::multisense::Ground_Surface : profile);
     profile |= (dyn.full_res_aux_profile ? crl::multisense::Full_Res_Aux_Cam : profile);
 
     cfg.setCameraProfile(profile);

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -93,6 +93,8 @@ int main(int argc, char** argvPP)
                                              std::bind(&multisense_ros::Camera::borderClipChanged, &camera,
                                                        std::placeholders::_1, std::placeholders::_2),
                                              std::bind(&multisense_ros::Camera::maxPointCloudRangeChanged, &camera,
+                                                       std::placeholders::_1),
+                                             std::bind(&multisense_ros::Camera::extrinsicsChanged, &camera,
                                                        std::placeholders::_1));
             ros::spin();
         }


### PR DESCRIPTION
Add support to ros driver to modify extrinsics on the fly. 

The parameter reconfigure callback updates the extrinsics on-board the multisense — this is important to tools such as ground surface modelling which run on the camera and rely on these extrinsics being set correctly.   

The callback also updates a transform member in the camera class, which allows the user to dynamically redraw the pointcloud position in the RVIZ window.

Change the TF Hierarchy as below for all Multisense URDF files, so that the camera from origin "extrinsics" transform affects the left_camera_optical_frame transform directly.
**Old TF Tree**: origin -> head -> left_camera_optical_frame 
**New TF Tree**: origin -> left_camera_optical_frame -> head

Video of functionality in action: https://drive.google.com/file/d/1awNOO51-T6IrX_JmlxeBvwosC_yvPWlx/view?usp=sharing

(Intended to be stacked on https://github.com/carnegierobotics/multisense_ros/pull/33)