### PR TITLE
Add LED Pulse Control Support to Dynamic Reconfigure

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -199,7 +199,7 @@ for cfg in sensorConfigList:
         gen.add("led_duty_cycle", double_t, 0, "DutyCycle", 0.0, 0.0, 1.0)
         if cfg.ar0234:
             gen.add("number_of_pulses", int_t, 0, "NumberOfPulses", 1, 0, 10)
-            gen.add("led_startup_time", int_t, 0, "LedStartupTime", 0, -10000, 10000)
+            gen.add("led_startup_time_us", int_t, 0, "LedStartupTimeUs", 0, -10000, 10000)
     #endif
 
     if cfg.motor:

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -199,7 +199,8 @@ for cfg in sensorConfigList:
         gen.add("led_duty_cycle", double_t, 0, "DutyCycle", 0.0, 0.0, 1.0)
         if cfg.ar0234:
             gen.add("number_of_pulses", int_t, 0, "NumberOfPulses", 1, 0, 10)
-            gen.add("led_startup_time_us", int_t, 0, "LedStartupTimeUs", 0, -10000, 10000)
+            gen.add("led_startup_time_us", int_t, 0, "LedStartupTimeUs", 0, 0, 30000)
+        #endif
     #endif
 
     if cfg.motor:

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -200,7 +200,7 @@ for cfg in sensorConfigList:
         if cfg.ar0234:
             gen.add("number_of_pulses", int_t, 0, "NumberOfPulses", 1, 0, 10)
             gen.add("led_startup_time_us", int_t, 0, "LedStartupTimeUs", 0, 0, 30000)
-            gen.add("invert_led_outputt", bool_t, 0, "InvertLedOutput", False)
+            gen.add("invert_led_output", bool_t, 0, "InvertLedOutput", False)
         #endif
     #endif
 

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -200,6 +200,7 @@ for cfg in sensorConfigList:
         if cfg.ar0234:
             gen.add("number_of_pulses", int_t, 0, "NumberOfPulses", 1, 0, 10)
             gen.add("led_startup_time_us", int_t, 0, "LedStartupTimeUs", 0, 0, 30000)
+            gen.add("invert_led_outputt", bool_t, 0, "InvertLedOutput", False)
         #endif
     #endif
 

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -197,6 +197,9 @@ for cfg in sensorConfigList:
         gen.add("lighting", bool_t, 0, "Lighting", False)
         gen.add("flash", bool_t, 0, "Flash", False)
         gen.add("led_duty_cycle", double_t, 0, "DutyCycle", 0.0, 0.0, 1.0)
+        if cfg.ar0234:
+            gen.add("number_of_pulses", int_t, 0, "NumberOfPulses", 1, 0, 10)
+            gen.add("led_startup_time", int_t, 0, "LedStartupTime", 0, -10000, 10000)
     #endif
 
     if cfg.motor:

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -99,6 +99,7 @@ private:
     template<class T> void configureCropMode(crl::multisense::image::Config& cfg, const T& dyn);
     template<class T> void configureMotor(const T& dyn);
     template<class T> void configureLeds(const T& dyn);
+    template<class T> void configureS19Leds(const T& dyn);
     template<class T> void configureImu(const T& dyn);
     template<class T> void configureBorderClip(const T& dyn);
     template<class T> void configurePointCloudRange(const T& dyn);

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -569,7 +569,7 @@ template<class T> void Reconfigure::configureLeds(const T& dyn)
             leds.setFlash(dyn.flash);
             leds.setDutyCycle(dyn.led_duty_cycle * 100.0);
             leds.setNumberOfPulses(dyn.number_of_pulses);
-            leds.setLedStartupTime(dyn.led_startup_time);
+            leds.setLedStartupTimeUs(dyn.led_startup_time_us);
         }
 
         Status status = driver_->setLightingConfig(leds);

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -598,7 +598,9 @@ template<class T> void Reconfigure::configureS19Leds(const T& dyn)
             leds.setFlash(dyn.flash);
             leds.setDutyCycle(dyn.led_duty_cycle * 100.0);
             leds.setNumberOfPulses(dyn.number_of_pulses);
-            leds.setLedStartupTime(dyn.led_startup_time_us);
+            leds.setLedStartupTime(dyn.invert_led_output ?
+                                       dyn.led_startup_time_us :
+                                       dyn.led_startup_time_us + 1000000);
         }
 
         Status status = driver_->setLightingConfig(leds);

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -568,6 +568,8 @@ template<class T> void Reconfigure::configureLeds(const T& dyn)
         } else {
             leds.setFlash(dyn.flash);
             leds.setDutyCycle(dyn.led_duty_cycle * 100.0);
+            leds.setNumberOfPulses(dyn.number_of_pulses);
+            leds.setLedStartupTime(dyn.led_startup_time);
         }
 
         Status status = driver_->setLightingConfig(leds);

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -568,8 +568,37 @@ template<class T> void Reconfigure::configureLeds(const T& dyn)
         } else {
             leds.setFlash(dyn.flash);
             leds.setDutyCycle(dyn.led_duty_cycle * 100.0);
+        }
+
+        Status status = driver_->setLightingConfig(leds);
+        if (Status_Ok != status) {
+            if (Status_Unsupported == status)
+                lighting_supported_ = false;
+            else
+                ROS_ERROR("Reconfigure: failed to set lighting config: %s",
+                          Channel::statusString(status));
+        }
+    }
+
+}
+
+template<class T> void Reconfigure::configureS19Leds(const T& dyn)
+{
+    //
+    // Send the desired lighting configuration
+
+    if (lighting_supported_) {
+
+        lighting::Config leds;
+
+        if (false == dyn.lighting) {
+            leds.setFlash(false);
+            leds.setDutyCycle(0.0);
+        } else {
+            leds.setFlash(dyn.flash);
+            leds.setDutyCycle(dyn.led_duty_cycle * 100.0);
             leds.setNumberOfPulses(dyn.number_of_pulses);
-            leds.setLedStartupTimeUs(dyn.led_startup_time_us);
+            leds.setLedStartupTime(dyn.led_startup_time_us);
         }
 
         Status status = driver_->setLightingConfig(leds);
@@ -840,7 +869,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureStereoProfile(cfg, dyn);                       \
         configureCamera(cfg, dyn);                              \
         configureBorderClip(dyn);                               \
-        configureLeds(dyn);                                     \
+        configureS19Leds(dyn);                                  \
         configurePtp(dyn);                                      \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -599,8 +599,8 @@ template<class T> void Reconfigure::configureS19Leds(const T& dyn)
             leds.setDutyCycle(dyn.led_duty_cycle * 100.0);
             leds.setNumberOfPulses(dyn.number_of_pulses);
             leds.setLedStartupTime(dyn.invert_led_output ?
-                                       dyn.led_startup_time_us :
-                                       dyn.led_startup_time_us + 1000000);
+                                       dyn.led_startup_time_us + 1000000 :
+                                       dyn.led_startup_time_us);
         }
 
         Status status = driver_->setLightingConfig(leds);


### PR DESCRIPTION
This PR adds LED pulse control to the dynamic reconfigure server for next gen stereo cameras that support lighting

Testing is still required