### PR TITLE
Support dynamic reconfigure of ground surface parameters

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -299,13 +299,12 @@ for cfg in sensorConfigList:
     # Ground Surface Parameters on supported on S27/S30
     if cfg.name.find('s27') != -1:
         gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
-        gen.add("ground_surface_pointcloud_max_range_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
-        gen.add("ground_surface_pointcloud_min_range_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.0, 0.0, 50.0)
-        gen.add("ground_surface_pointcloud_max_width_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
-        gen.add("ground_surface_pointcloud_min_width_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
-        gen.add("ground_surface_pointcloud_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
-        gen.add("ground_surface_pointcloud_min_height_m", double_t, 0, "Minimum pointcloud range for B-spline fit", -10.0, -50.0, 0.0)
-
+        gen.add("ground_surface_pointcloud_global_max_z_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
+        gen.add("ground_surface_pointcloud_global_min_z_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.5, 0.0, 50.0)
+        gen.add("ground_surface_pointcloud_global_max_x_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
+        gen.add("ground_surface_pointcloud_global_min_x_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
+        gen.add("ground_surface_pointcloud_global_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
+        gen.add("ground_surface_pointcloud_global_min_height_m", double_t, 0, "Minimum pointcloud height for B-spline fit", -10.0, -50.0, 0.0)
         gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)
         gen.add("ground_surface_spline_resolution_z", int_t, 0, "Number of spline levels in the left camera optical frame's z dimension", 4, 0, 10)
         base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -293,29 +293,29 @@ for cfg in sensorConfigList:
     gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
 
     # Ground Surface Parameters
-    gen.add("ground_surface_number_of_levels_x", int_t, 0, "Number of spline levels in the camera's x dimension", 4, 0, 10)
-    gen.add("ground_surface_number_of_levels_z", int_t, 0, "Number of spline levels in the camera's z dimension", 4, 0, 10)
+    gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
+    gen.add("ground_surface_pointcloud_max_range_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_min_range_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_max_width_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_min_width_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
+    gen.add("ground_surface_pointcloud_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_min_height_m", double_t, 0, "Minimum pointcloud range for B-spline fit", -10.0, -50.0, 0.0)
 
+    gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)
+    gen.add("ground_surface_spline_resolution_z", int_t, 0, "Number of spline levels in the left camera optical frame's z dimension", 4, 0, 10)
     base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),
                          gen.const("Mean", str_t, "Mean", "Mean"),
                          gen.const("Zero", str_t, "Zero", "Zero")],
                         "Available base model settings");
-    gen.add("ground_surface_base_model", str_t, 0, "desc", "Mean", edit_method=base_model_enum);
+    gen.add("ground_surface_pre_transform_data", str_t, 0, "Model to transform raw data with before performing B-Spline fit", "Mean", edit_method=base_model_enum);
 
-    gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "desc", 0.5, 0.01, 1.0)
-    gen.add("ground_surface_min_points_per_grid", int_t, 0, "desc", 10, 0, 100)
-    gen.add("ground_surface_pointcloud_decimation", int_t, 0, "desc", 1, 1, 4)
-    gen.add("ground_surface_pointcloud_max_range_m", double_t, 0, "desc", 30.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_min_range_m", double_t, 0, "desc", 0.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_max_width_m", double_t, 0, "desc", 25.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_min_width_m", double_t, 0, "desc", -25.0, -50.0, 0.0)
-    gen.add("ground_surface_pointcloud_max_height_m", double_t, 0, "desc", 10.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_min_height_m", double_t, 0, "desc", -10.0, -50.0, 0.0)
-    gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "desc", 2.0, 0.0, 10.0)
-    gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "desc", 0.50, 0.0, 1.0)
-    gen.add("ground_surface_spline_draw_resolution", double_t, 0, "desc", 0.1, 0.01, 1.0)
-    gen.add("ground_surface_max_fitting_iterations", int_t, 0, "desc", 10, 1, 30)
-    gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "desc", 1.5, 0.0, 5.0)
+    gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled  upon — larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
+    gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process — used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
+    gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "Obstacle height in meters", 2.0, 0.0, 10.0)
+    gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "Percentage of points in XZ cell column which must be above obstacle height threshold to consider the cell an obstacle", 0.50, 0.0, 1.0)
+    gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)
+    gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "ADVANCED SETTING: Border size around obstacle cells to examine during iterative B-spline routine", 1.5, 0.0, 5.0)
+    gen.add("ground_surface_spline_draw_resolution", double_t, 0, "Resolution to draw resulting B-Spline model with in RVIZ", 0.1, 0.01, 1.0)
 
     gen.generate(PACKAGE, cfg.name, cfg.name)
 #endfor

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -215,8 +215,12 @@ for cfg in sensorConfigList:
         gen.add("detail_disparity_profile", bool_t, 0, "DetailDisparityProfile", False);
         gen.add("high_contrast_profile", bool_t, 0, "HighContrastProfile", False);
         gen.add("show_roi_profile", bool_t, 0, "ShowRoiProfile", False);
-        gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
         gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
+
+        # Ground Surface Parameters on supported on S27/S30
+        if cfg.name.find('s27') != -1:
+            gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
+        #endif
     #endif
 
     if cfg.imu:
@@ -292,31 +296,32 @@ for cfg in sensorConfigList:
     gen.add("origin_from_camera_rotation_y_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation y (deg)", 0.0, -180.0, 180.0)
     gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
 
-    # Ground Surface Parameters
-    # TODO(drobinson): Restrinct visibilty to supported S27 / S30 cameras
-    gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
-    gen.add("ground_surface_pointcloud_max_range_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_min_range_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_max_width_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_min_width_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
-    gen.add("ground_surface_pointcloud_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_min_height_m", double_t, 0, "Minimum pointcloud range for B-spline fit", -10.0, -50.0, 0.0)
+    # Ground Surface Parameters on supported on S27/S30
+    if cfg.name.find('s27') != -1:
+        gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
+        gen.add("ground_surface_pointcloud_max_range_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
+        gen.add("ground_surface_pointcloud_min_range_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.0, 0.0, 50.0)
+        gen.add("ground_surface_pointcloud_max_width_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
+        gen.add("ground_surface_pointcloud_min_width_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
+        gen.add("ground_surface_pointcloud_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
+        gen.add("ground_surface_pointcloud_min_height_m", double_t, 0, "Minimum pointcloud range for B-spline fit", -10.0, -50.0, 0.0)
 
-    gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)
-    gen.add("ground_surface_spline_resolution_z", int_t, 0, "Number of spline levels in the left camera optical frame's z dimension", 4, 0, 10)
-    base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),
-                         gen.const("Mean", str_t, "Mean", "Mean"),
-                         gen.const("Zero", str_t, "Zero", "Zero")],
-                        "Available base model settings");
-    gen.add("ground_surface_pre_transform_data", str_t, 0, "Model to transform raw data with before performing B-Spline fit", "Mean", edit_method=base_model_enum);
+        gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)
+        gen.add("ground_surface_spline_resolution_z", int_t, 0, "Number of spline levels in the left camera optical frame's z dimension", 4, 0, 10)
+        base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),
+                            gen.const("Mean", str_t, "Mean", "Mean"),
+                            gen.const("Zero", str_t, "Zero", "Zero")],
+                            "Available base model settings");
+        gen.add("ground_surface_pre_transform_data", str_t, 0, "Model to transform raw data with before performing B-Spline fit", "Mean", edit_method=base_model_enum);
 
-    gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled  upon — larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
-    gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process — used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
-    gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "Obstacle height in meters", 2.0, 0.0, 10.0)
-    gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "Percentage of points in XZ cell column which must be above obstacle height threshold to consider the cell an obstacle", 0.50, 0.0, 1.0)
-    gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)
-    gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "ADVANCED SETTING: Border size around obstacle cells to examine during iterative B-spline routine", 1.5, 0.0, 5.0)
-    gen.add("ground_surface_spline_draw_resolution", double_t, 0, "Resolution to draw resulting B-Spline model with in RVIZ", 0.1, 0.01, 1.0)
+        gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled  upon — larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
+        gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process — used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
+        gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "Obstacle height in meters", 2.0, 0.0, 10.0)
+        gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "Percentage of points in XZ cell column which must be above obstacle height threshold to consider the cell an obstacle", 0.50, 0.0, 1.0)
+        gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)
+        gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "ADVANCED SETTING: Border size around obstacle cells to examine during iterative B-spline routine", 1.5, 0.0, 5.0)
+        gen.add("ground_surface_spline_draw_resolution", double_t, 0, "Resolution to draw resulting B-Spline model with in RVIZ", 0.1, 0.01, 1.0)
+    # endif
 
     gen.generate(PACKAGE, cfg.name, cfg.name)
 #endfor

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -292,6 +292,31 @@ for cfg in sensorConfigList:
     gen.add("origin_from_camera_rotation_y_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation y (deg)", 0.0, -180.0, 180.0)
     gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
 
+    # Ground Surface Parameters
+    gen.add("ground_surface_number_of_levels_x", int_t, 0, "Number of spline levels in the camera's x dimension", 4, 0, 10)
+    gen.add("ground_surface_number_of_levels_z", int_t, 0, "Number of spline levels in the camera's z dimension", 4, 0, 10)
+
+    base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),
+                         gen.const("Mean", str_t, "Mean", "Mean"),
+                         gen.const("Zero", str_t, "Zero", "Zero")],
+                        "Available base model settings");
+    gen.add("ground_surface_base_model", str_t, 0, "desc", "Mean", edit_method=base_model_enum);
+
+    gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "desc", 0.5, 0.01, 1.0)
+    gen.add("ground_surface_min_points_per_grid", int_t, 0, "desc", 10, 0, 100)
+    gen.add("ground_surface_pointcloud_decimation", int_t, 0, "desc", 1, 1, 4)
+    gen.add("ground_surface_pointcloud_max_range_m", double_t, 0, "desc", 30.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_min_range_m", double_t, 0, "desc", 0.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_max_width_m", double_t, 0, "desc", 25.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_min_width_m", double_t, 0, "desc", -25.0, -50.0, 0.0)
+    gen.add("ground_surface_pointcloud_max_height_m", double_t, 0, "desc", 10.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_min_height_m", double_t, 0, "desc", -10.0, -50.0, 0.0)
+    gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "desc", 2.0, 0.0, 10.0)
+    gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "desc", 0.50, 0.0, 1.0)
+    gen.add("ground_surface_spline_draw_resolution", double_t, 0, "desc", 0.1, 0.01, 1.0)
+    gen.add("ground_surface_max_fitting_iterations", int_t, 0, "desc", 10, 1, 30)
+    gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "desc", 1.5, 0.0, 5.0)
+
     gen.generate(PACKAGE, cfg.name, cfg.name)
 #endfor
 

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -311,7 +311,7 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             gen.add("ground_surface_pointcloud_global_max_z_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
             gen.add("ground_surface_pointcloud_global_min_z_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.5, 0.0, 50.0)
             gen.add("ground_surface_pointcloud_global_max_x_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
-            gen.add("ground_surface_pointcloud_global_min_x_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
+            gen.add("ground_surface_pointcloud_global_min_x_m", double_t, 0, "Minimum pointcloud width (RHS distance) for B-spline fit", -25.0, -50.0, 0.0)
             gen.add("ground_surface_pointcloud_global_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
             gen.add("ground_surface_pointcloud_global_min_height_m", double_t, 0, "Minimum pointcloud height for B-spline fit", -10.0, -50.0, 0.0)
             gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -322,8 +322,8 @@ for feature_name, feature in SupportedFeatures.__members__.items():
                                 "Available base model settings");
             gen.add("ground_surface_pre_transform_data", str_t, 0, "Model to transform raw data with before performing B-Spline fit", "Mean", edit_method=base_model_enum);
 
-            gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled  upon — larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
-            gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process — used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
+            gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled upon, larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
+            gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process, used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
             gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "Obstacle height in meters", 2.0, 0.0, 10.0)
             gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "Percentage of points in XZ cell column which must be above obstacle height threshold to consider the cell an obstacle", 0.50, 0.0, 1.0)
             gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -216,8 +216,6 @@ for cfg in sensorConfigList:
         gen.add("high_contrast_profile", bool_t, 0, "HighContrastProfile", False);
         gen.add("show_roi_profile", bool_t, 0, "ShowRoiProfile", False);
         gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
-
-        # Ground Surface Parameters on supported on S27/S30
         gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
     #endif
 
@@ -294,7 +292,6 @@ for cfg in sensorConfigList:
     gen.add("origin_from_camera_rotation_y_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation y (deg)", 0.0, -180.0, 180.0)
     gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
 
-    # Ground Surface Parameters on supported on S27/S30
     gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
     gen.add("ground_surface_pointcloud_global_max_z_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
     gen.add("ground_surface_pointcloud_global_min_z_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.5, 0.0, 50.0)

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -218,9 +218,7 @@ for cfg in sensorConfigList:
         gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
 
         # Ground Surface Parameters on supported on S27/S30
-        if cfg.name.find('s27') != -1:
-            gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
-        #endif
+        gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
     #endif
 
     if cfg.imu:
@@ -297,30 +295,28 @@ for cfg in sensorConfigList:
     gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
 
     # Ground Surface Parameters on supported on S27/S30
-    if cfg.name.find('s27') != -1:
-        gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
-        gen.add("ground_surface_pointcloud_global_max_z_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
-        gen.add("ground_surface_pointcloud_global_min_z_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.5, 0.0, 50.0)
-        gen.add("ground_surface_pointcloud_global_max_x_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
-        gen.add("ground_surface_pointcloud_global_min_x_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
-        gen.add("ground_surface_pointcloud_global_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
-        gen.add("ground_surface_pointcloud_global_min_height_m", double_t, 0, "Minimum pointcloud height for B-spline fit", -10.0, -50.0, 0.0)
-        gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)
-        gen.add("ground_surface_spline_resolution_z", int_t, 0, "Number of spline levels in the left camera optical frame's z dimension", 4, 0, 10)
-        base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),
-                            gen.const("Mean", str_t, "Mean", "Mean"),
-                            gen.const("Zero", str_t, "Zero", "Zero")],
-                            "Available base model settings");
-        gen.add("ground_surface_pre_transform_data", str_t, 0, "Model to transform raw data with before performing B-Spline fit", "Mean", edit_method=base_model_enum);
+    gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
+    gen.add("ground_surface_pointcloud_global_max_z_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_global_min_z_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.5, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_global_max_x_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_global_min_x_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
+    gen.add("ground_surface_pointcloud_global_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
+    gen.add("ground_surface_pointcloud_global_min_height_m", double_t, 0, "Minimum pointcloud height for B-spline fit", -10.0, -50.0, 0.0)
+    gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)
+    gen.add("ground_surface_spline_resolution_z", int_t, 0, "Number of spline levels in the left camera optical frame's z dimension", 4, 0, 10)
+    base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),
+                        gen.const("Mean", str_t, "Mean", "Mean"),
+                        gen.const("Zero", str_t, "Zero", "Zero")],
+                        "Available base model settings");
+    gen.add("ground_surface_pre_transform_data", str_t, 0, "Model to transform raw data with before performing B-Spline fit", "Mean", edit_method=base_model_enum);
 
-        gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled  upon — larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
-        gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process — used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
-        gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "Obstacle height in meters", 2.0, 0.0, 10.0)
-        gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "Percentage of points in XZ cell column which must be above obstacle height threshold to consider the cell an obstacle", 0.50, 0.0, 1.0)
-        gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)
-        gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "ADVANCED SETTING: Border size around obstacle cells to examine during iterative B-spline routine", 1.5, 0.0, 5.0)
-        gen.add("ground_surface_spline_draw_resolution", double_t, 0, "Resolution to draw resulting B-Spline model with in RVIZ", 0.1, 0.01, 1.0)
-    # endif
+    gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled  upon — larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
+    gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process — used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
+    gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "Obstacle height in meters", 2.0, 0.0, 10.0)
+    gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "Percentage of points in XZ cell column which must be above obstacle height threshold to consider the cell an obstacle", 0.50, 0.0, 1.0)
+    gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)
+    gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "ADVANCED SETTING: Border size around obstacle cells to examine during iterative B-spline routine", 1.5, 0.0, 5.0)
+    gen.add("ground_surface_spline_draw_resolution", double_t, 0, "Resolution to draw resulting B-Spline model with in RVIZ", 0.1, 0.01, 1.0)
 
     gen.generate(PACKAGE, cfg.name, cfg.name)
 #endfor

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -2,6 +2,7 @@
 PACKAGE = "multisense_ros"
 import os
 import roslib;roslib.load_manifest(PACKAGE)
+from enum import Enum
 
 if os.path.isfile('../../stack.xml'):
     from dynamic_reconfigure.parameter_generator import *
@@ -9,7 +10,7 @@ else:
     from dynamic_reconfigure.parameter_generator_catkin import *
 
 class SensorConfig(object):
-    def __init__(self, name=None, sgm=False, motor=False, imu=False, lighting=False, aux=False, ar0234=False):
+    def __init__(self, name=None, sgm=False, motor=False, imu=False, lighting=False, aux=False, ar0234=False, features=False):
         self.name     = name
         self.sgm      = sgm
         self.motor    = motor
@@ -17,305 +18,327 @@ class SensorConfig(object):
         self.lighting = lighting
         self.aux      = aux
         self.ar0234   = ar0234
+        self.features = features
     #enddef
 #endclass
 
+class SupportedFeatures(Enum):
+    NONE = 0
+    GROUND_SURFACE = 1
+
 sensorConfigList = []
-sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000",      sgm=False, motor=True,  imu=False, lighting=True , aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000_imu",  sgm=False, motor=True,  imu=True , lighting=True , aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="sl_bm_cmv4000",      sgm=False, motor=True,  imu=False, lighting=True , aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="sl_bm_cmv4000_imu",  sgm=False, motor=True,  imu=True , lighting=True , aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="sl_sgm_cmv2000_imu", sgm=True,  motor=True,  imu=True , lighting=True , aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="sl_sgm_cmv4000_imu", sgm=True,  motor=True,  imu=True , lighting=True , aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="st21_sgm_vga_imu",   sgm=True,  motor=False, imu=True , lighting=False, aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="mono_cmv2000",       sgm=False, motor=False, imu=True , lighting=True , aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="mono_cmv4000",       sgm=False, motor=False, imu=True , lighting=True , aux=False, ar0234=False))
-sensorConfigList.append(SensorConfig(name="s27_sgm_AR0234",     sgm=True,  motor=False, imu=False, lighting=False, aux=True, ar0234=True))
-sensorConfigList.append(SensorConfig(name="ks21_sgm_AR0234",    sgm=True,  motor=False, imu=False, lighting=True , aux=False, ar0234=True))
+sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000",      sgm=False, motor=True,  imu=False, lighting=True , aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000_imu",  sgm=False, motor=True,  imu=True , lighting=True , aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="sl_bm_cmv4000",      sgm=False, motor=True,  imu=False, lighting=True , aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="sl_bm_cmv4000_imu",  sgm=False, motor=True,  imu=True , lighting=True , aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="sl_sgm_cmv2000_imu", sgm=True,  motor=True,  imu=True , lighting=True , aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="sl_sgm_cmv4000_imu", sgm=True,  motor=True,  imu=True , lighting=True , aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="st21_sgm_vga_imu",   sgm=True,  motor=False, imu=True , lighting=False, aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="mono_cmv2000",       sgm=False, motor=False, imu=True , lighting=True , aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="mono_cmv4000",       sgm=False, motor=False, imu=True , lighting=True , aux=False, ar0234=False, features=False))
+sensorConfigList.append(SensorConfig(name="s27_sgm_AR0234",     sgm=True,  motor=False, imu=False, lighting=False, aux=True,  ar0234=True , features=True))
+sensorConfigList.append(SensorConfig(name="ks21_sgm_AR0234",    sgm=True,  motor=False, imu=False, lighting=True , aux=False, ar0234=True , features=True))
 
-for cfg in sensorConfigList:
-    gen = ParameterGenerator()
+for feature_name, feature in SupportedFeatures.__members__.items():
+    for cfg in sensorConfigList:
+        # Don't add feature config for unsupported cameras
+        if not cfg.features and feature != SupportedFeatures.NONE:
+            continue
 
-    roi_width = None
-    roi_height = None
-    auto_exposure_threshold = 0.75
+        gen = ParameterGenerator()
 
-    if cfg.name.find('sgm_cmv2000') != -1:
-        res_enum = gen.enum([ gen.const("1024x272_64_disparities", str_t, "1024x272x64", "1024x272x64"),
-                              gen.const("1024x272_128_disparities", str_t, "1024x272x128", "1024x272x128"),
-                              gen.const("1024x272_256_disparities", str_t, "1024x272x256", "1024x272x256"),
-                              gen.const("1024x544_64_disparities", str_t, "1024x544x64", "1024x544x64"),
-                              gen.const("1024x544_128_disparities", str_t, "1024x544x128", "1024x544x128"),
-                              gen.const("1024x544_256_disparities", str_t, "1024x544x256", "1024x544x256"),
-                              gen.const("2048x544_64_disparities", str_t, "2048x544x64", "2048x544x64"),
-                              gen.const("2048x544_128_disparities", str_t, "2048x544x128", "2048x544x128"),
-                              gen.const("2048x544_256_disparities", str_t, "2048x544x256", "2048x544x256"),
-                              gen.const("2048x1088_64_disparities", str_t, "2048x1088x64", "2048x1088x64"),
-                              gen.const("2048x1088_128_disparities", str_t, "2048x1088x128", "2048x1088x128"),
-                              gen.const("2048x1088_256_disparities", str_t, "2048x1088x256", "2048x1088x256") ],
-                            "Available resolution settings")
-        gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x128", edit_method=res_enum)
-        gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
-        roi_width = 2048
-        roi_height = 1088
-    elif cfg.name.find('sgm_cmv4000') != -1:
-        res_enum = gen.enum([ gen.const("1024x512_64_disparities", str_t, "1024x512x64", "1024x512x64"),
-                              gen.const("1024x512_128_disparities", str_t, "1024x512x128", "1024x512x128"),
-                              gen.const("1024x512_256_disparities", str_t, "1024x512x256", "1024x512x256"),
-                              gen.const("1024x1024_64_disparities", str_t, "1024x1024x64", "1024x1024x64"),
-                              gen.const("1024x1024_128_disparities", str_t, "1024x1024x128", "1024x1024x128"),
-                              gen.const("1024x1024_256_disparities", str_t, "1024x1024x256", "1024x1024x256"),
-                              gen.const("2048x1024_64_disparities", str_t, "2048x1024x64", "2048x1024x64"),
-                              gen.const("2048x1024_128_disparities", str_t, "2048x1024x128", "2048x1024x128"),
-                              gen.const("2048x1024_256_disparities", str_t, "2048x1024x256", "2048x1024x256"),
-                              gen.const("2048x2048_64_disparities", str_t, "2048x2048x64", "2048x2048x64"),
-                              gen.const("2048x2048_128_disparities", str_t, "2048x2048x128", "2048x2048x128"),
-                              gen.const("2048x2048_256_disparities", str_t, "2048x2048x256", "2048x2048x256") ],
-                            "Available resolution settings")
-        gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x128", edit_method=res_enum)
-        gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
-        roi_width = 2048
-        roi_height = 2048
-    elif cfg.name.find('bm_cmv2000') != -1:
-        res_enum = gen.enum([ gen.const("1024x544_128_disparities", str_t, "1024x544x128", "1024x544x128"),
-                              gen.const("2048x1088_No_disparities", str_t, "2048x1088x0", "2048x1088x0") ],
-                            "Available resolution settings")
-        gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x128", edit_method=res_enum)
-        gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
-        roi_width = 2048
-        roi_height = 1088
-    elif cfg.name.find('bm_cmv4000') != -1:
-        res_enum = gen.enum([ gen.const("1024x1024_128_disparities", str_t, "1024x1024x128", "1024x1024x128"),
-                              gen.const("2048x2048_No_disparities", str_t, "2048x2048x0", "2048x2048x0") ],
-                            "Available resolution settings")
-        gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x128", edit_method=res_enum)
-        gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
-        roi_width = 2048
-        roi_height = 2048
-    elif cfg.name.find('st21_sgm_vga_imu') != -1:
-        res_enum = gen.enum([ gen.const("640x512_64_disparities", str_t, "640x512x64", "640x512x64"),
-                              gen.const("640x512_128_disparities", str_t, "640x512x128", "640x512x128") ],
-                            "Available resolution settings")
-        gen.add("resolution", str_t, 0, "sensor resolution", "640x512x128", edit_method=res_enum)
-        gen.add("fps", double_t, 0, "FPS", 29.97, 20.0, 29.97)
-    elif cfg.name.find('mono_cmv2000') != -1:
-        res_enum = gen.enum([ gen.const("1024x272", str_t, "1024x272x0", "1024x272x0"),
-                              gen.const("1024x544", str_t, "1024x544x0", "1024x544x0"),
-                              gen.const("2048x544", str_t, "2048x544x0", "2048x544x0"),
-                              gen.const("2048x1088", str_t, "2048x1088x0", "2048x1088x0") ],
-                            "Available resolution settings")
-        gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x0", edit_method=res_enum)
-        gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
-        roi_width = 2048
-        roi_height = 1088
-    elif cfg.name.find('mono_cmv4000') != -1:
-        res_enum = gen.enum([ gen.const("1024x512", str_t, "1024x512x0", "1024x512x0"),
-                              gen.const("1024x1024", str_t, "1024x1024x0", "1024x1024x0"),
-                              gen.const("2048x1024", str_t, "2048x1024x0", "2048x1024x0"),
-                              gen.const("2048x2048", str_t, "2048x2048x0", "2048x2048x0") ],
-                            "Available resolution settings")
-        gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x0", edit_method=res_enum)
-        gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
-        roi_width = 2048
-        roi_height = 2048
-    elif cfg.ar0234:
-        res_enum = gen.enum([ gen.const("960x600_256_disparities", str_t, "960x600x256", "960x600x256"),
-                              gen.const("1920x1200_64_disparities", str_t, "1920x1200x64", "1920x1200x64"),
-                              gen.const("1920x1200_128_disparities", str_t, "1920x1200x128", "1920x1200x128"),
-                              gen.const("1920x1200_256_disparities", str_t, "1920x1200x256", "1920x1200x256") ],
-                            "Available resolution settings")
-        gen.add("resolution", str_t, 0, "sensor resolution", "960x600x256", edit_method=res_enum)
-        gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 64.0)
-        roi_width = 1920
-        roi_height = 1200
-        auto_exposure_threshold = 0.95
-    #endif
+        roi_width = None
+        roi_height = None
+        auto_exposure_threshold = 0.75
 
-    if cfg.name.find('st21_sgm_vga_imu') == -1:
-        gen.add("desired_transmit_delay", int_t, 0, "desired_transmit_delay (ms)", 0, 0, 500)
-    #endif
+        if cfg.name.find('sgm_cmv2000') != -1:
+            res_enum = gen.enum([ gen.const("1024x272_64_disparities", str_t, "1024x272x64", "1024x272x64"),
+                                gen.const("1024x272_128_disparities", str_t, "1024x272x128", "1024x272x128"),
+                                gen.const("1024x272_256_disparities", str_t, "1024x272x256", "1024x272x256"),
+                                gen.const("1024x544_64_disparities", str_t, "1024x544x64", "1024x544x64"),
+                                gen.const("1024x544_128_disparities", str_t, "1024x544x128", "1024x544x128"),
+                                gen.const("1024x544_256_disparities", str_t, "1024x544x256", "1024x544x256"),
+                                gen.const("2048x544_64_disparities", str_t, "2048x544x64", "2048x544x64"),
+                                gen.const("2048x544_128_disparities", str_t, "2048x544x128", "2048x544x128"),
+                                gen.const("2048x544_256_disparities", str_t, "2048x544x256", "2048x544x256"),
+                                gen.const("2048x1088_64_disparities", str_t, "2048x1088x64", "2048x1088x64"),
+                                gen.const("2048x1088_128_disparities", str_t, "2048x1088x128", "2048x1088x128"),
+                                gen.const("2048x1088_256_disparities", str_t, "2048x1088x256", "2048x1088x256") ],
+                                "Available resolution settings")
+            gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x128", edit_method=res_enum)
+            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
+            roi_width = 2048
+            roi_height = 1088
+        elif cfg.name.find('sgm_cmv4000') != -1:
+            res_enum = gen.enum([ gen.const("1024x512_64_disparities", str_t, "1024x512x64", "1024x512x64"),
+                                gen.const("1024x512_128_disparities", str_t, "1024x512x128", "1024x512x128"),
+                                gen.const("1024x512_256_disparities", str_t, "1024x512x256", "1024x512x256"),
+                                gen.const("1024x1024_64_disparities", str_t, "1024x1024x64", "1024x1024x64"),
+                                gen.const("1024x1024_128_disparities", str_t, "1024x1024x128", "1024x1024x128"),
+                                gen.const("1024x1024_256_disparities", str_t, "1024x1024x256", "1024x1024x256"),
+                                gen.const("2048x1024_64_disparities", str_t, "2048x1024x64", "2048x1024x64"),
+                                gen.const("2048x1024_128_disparities", str_t, "2048x1024x128", "2048x1024x128"),
+                                gen.const("2048x1024_256_disparities", str_t, "2048x1024x256", "2048x1024x256"),
+                                gen.const("2048x2048_64_disparities", str_t, "2048x2048x64", "2048x2048x64"),
+                                gen.const("2048x2048_128_disparities", str_t, "2048x2048x128", "2048x2048x128"),
+                                gen.const("2048x2048_256_disparities", str_t, "2048x2048x256", "2048x2048x256") ],
+                                "Available resolution settings")
+            gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x128", edit_method=res_enum)
+            gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
+            roi_width = 2048
+            roi_height = 2048
+        elif cfg.name.find('bm_cmv2000') != -1:
+            res_enum = gen.enum([ gen.const("1024x544_128_disparities", str_t, "1024x544x128", "1024x544x128"),
+                                gen.const("2048x1088_No_disparities", str_t, "2048x1088x0", "2048x1088x0") ],
+                                "Available resolution settings")
+            gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x128", edit_method=res_enum)
+            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
+            roi_width = 2048
+            roi_height = 1088
+        elif cfg.name.find('bm_cmv4000') != -1:
+            res_enum = gen.enum([ gen.const("1024x1024_128_disparities", str_t, "1024x1024x128", "1024x1024x128"),
+                                gen.const("2048x2048_No_disparities", str_t, "2048x2048x0", "2048x2048x0") ],
+                                "Available resolution settings")
+            gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x128", edit_method=res_enum)
+            gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
+            roi_width = 2048
+            roi_height = 2048
+        elif cfg.name.find('st21_sgm_vga_imu') != -1:
+            res_enum = gen.enum([ gen.const("640x512_64_disparities", str_t, "640x512x64", "640x512x64"),
+                                gen.const("640x512_128_disparities", str_t, "640x512x128", "640x512x128") ],
+                                "Available resolution settings")
+            gen.add("resolution", str_t, 0, "sensor resolution", "640x512x128", edit_method=res_enum)
+            gen.add("fps", double_t, 0, "FPS", 29.97, 20.0, 29.97)
+        elif cfg.name.find('mono_cmv2000') != -1:
+            res_enum = gen.enum([ gen.const("1024x272", str_t, "1024x272x0", "1024x272x0"),
+                                gen.const("1024x544", str_t, "1024x544x0", "1024x544x0"),
+                                gen.const("2048x544", str_t, "2048x544x0", "2048x544x0"),
+                                gen.const("2048x1088", str_t, "2048x1088x0", "2048x1088x0") ],
+                                "Available resolution settings")
+            gen.add("resolution", str_t, 0, "sensor resolution", "1024x544x0", edit_method=res_enum)
+            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
+            roi_width = 2048
+            roi_height = 1088
+        elif cfg.name.find('mono_cmv4000') != -1:
+            res_enum = gen.enum([ gen.const("1024x512", str_t, "1024x512x0", "1024x512x0"),
+                                gen.const("1024x1024", str_t, "1024x1024x0", "1024x1024x0"),
+                                gen.const("2048x1024", str_t, "2048x1024x0", "2048x1024x0"),
+                                gen.const("2048x2048", str_t, "2048x2048x0", "2048x2048x0") ],
+                                "Available resolution settings")
+            gen.add("resolution", str_t, 0, "sensor resolution", "1024x1024x0", edit_method=res_enum)
+            gen.add("fps", double_t, 0, "FPS", 5.0, 1.0, 15.0)
+            roi_width = 2048
+            roi_height = 2048
+        elif cfg.ar0234:
+            res_enum = gen.enum([ gen.const("960x600_256_disparities", str_t, "960x600x256", "960x600x256"),
+                                gen.const("1920x1200_64_disparities", str_t, "1920x1200x64", "1920x1200x64"),
+                                gen.const("1920x1200_128_disparities", str_t, "1920x1200x128", "1920x1200x128"),
+                                gen.const("1920x1200_256_disparities", str_t, "1920x1200x256", "1920x1200x256") ],
+                                "Available resolution settings")
+            gen.add("resolution", str_t, 0, "sensor resolution", "960x600x256", edit_method=res_enum)
+            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 64.0)
+            roi_width = 1920
+            roi_height = 1200
+            auto_exposure_threshold = 0.95
+        #endif
 
-    if cfg.name.find('sgm_cmv4000') != -1:
-        gen.add("crop_mode", bool_t, 0, "Crop image to 2MP", False)
-        gen.add("crop_offset", int_t, 0, "Crop Offset", 480, 0, 960)
-    #endif
+        if cfg.name.find('st21_sgm_vga_imu') == -1:
+            gen.add("desired_transmit_delay", int_t, 0, "desired_transmit_delay (ms)", 0, 0, 500)
+        #endif
 
-    if cfg.name.find('st21_sgm_vga_imu') == -1:
-        gen.add("gain", double_t, 0, "SensorGain", 1.0, 1.0, 8.0)
-        gen.add("auto_exposure", bool_t, 0, "AutoExposure", True)
-        gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.5, 0.0, 0.5);
-        gen.add("auto_exposure_decay", int_t, 0, "AutoExposureDecay", 7, 0, 20)
-        gen.add("auto_exposure_thresh", double_t, 0, "AutoExposureThresh", auto_exposure_threshold, 0.0, 1.0)
-        gen.add("auto_exposure_target_intensity", double_t, 0, "AutoExposureTargetIntensity", 0.5, 0.0, 1.0)
-        gen.add("exposure_time", double_t, 0, "Exposure", 0.025, 0, 0.5)
+        if cfg.name.find('sgm_cmv4000') != -1:
+            gen.add("crop_mode", bool_t, 0, "Crop image to 2MP", False)
+            gen.add("crop_offset", int_t, 0, "Crop Offset", 480, 0, 960)
+        #endif
 
-        if not cfg.ar0234:
+        if cfg.name.find('st21_sgm_vga_imu') == -1:
+            gen.add("gain", double_t, 0, "SensorGain", 1.0, 1.0, 8.0)
+            gen.add("auto_exposure", bool_t, 0, "AutoExposure", True)
+            gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.5, 0.0, 0.5);
+            gen.add("auto_exposure_decay", int_t, 0, "AutoExposureDecay", 7, 0, 20)
+            gen.add("auto_exposure_thresh", double_t, 0, "AutoExposureThresh", auto_exposure_threshold, 0.0, 1.0)
+            gen.add("auto_exposure_target_intensity", double_t, 0, "AutoExposureTargetIntensity", 0.5, 0.0, 1.0)
+            gen.add("exposure_time", double_t, 0, "Exposure", 0.025, 0, 0.5)
+
+            if not cfg.ar0234:
+                gen.add("auto_white_balance", bool_t, 0, "AutoWhiteBalance", True)
+                gen.add("auto_white_balance_decay", int_t, 0, "AutoWhiteBalanceDecay", 3, 0, 20)
+                gen.add("auto_white_balance_thresh", double_t, 0, "AutoWhiteBalanceThresh", 0.5, 0.0, 1.0)
+                gen.add("white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
+                gen.add("white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
+                gen.add("hdr_enable", bool_t, 0, "HDR Enable", False)
+            #endif
+
+            if roi_width is not None and roi_height is not None:
+                gen.add("roi_auto_exposure", bool_t, 0, "RoiAutoExposure", False)
+                gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, roi_width)
+                gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, roi_height)
+                gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, roi_width)
+                gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, roi_height)
+        #endif
+
+        if cfg.aux:
             gen.add("auto_white_balance", bool_t, 0, "AutoWhiteBalance", True)
             gen.add("auto_white_balance_decay", int_t, 0, "AutoWhiteBalanceDecay", 3, 0, 20)
             gen.add("auto_white_balance_thresh", double_t, 0, "AutoWhiteBalanceThresh", 0.5, 0.0, 1.0)
             gen.add("white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
             gen.add("white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
-            gen.add("hdr_enable", bool_t, 0, "HDR Enable", False)
+
+            gen.add("enable_aux_controls", bool_t, 0, "AuxSensorControls", False)
+            gen.add("aux_gain", double_t, 0, "AuxSensorGain", 1.0, 1.0, 8.0)
+            gen.add("aux_auto_exposure", bool_t, 0, "AuxAutoExposure", True)
+            gen.add("aux_auto_exposure_max_time", double_t, 0, "AuxAutoExposureMaxTime", 0.5, 0.0, 0.5);
+            gen.add("aux_auto_exposure_decay", int_t, 0, "AuxAutoExposureDecay", 7, 0, 20)
+            gen.add("aux_auto_exposure_thresh", double_t, 0, "AuxAutoExposureThresh", auto_exposure_threshold, 0.0, 1.0)
+            gen.add("aux_auto_exposure_target_intensity", double_t, 0, "AuxAutoExposureTargetIntensity", 0.5, 0.0, 1.0)
+            gen.add("aux_exposure_time", double_t, 0, "AuxExposure", 0.025, 0, 0.5)
+            gen.add("aux_roi_auto_exposure", bool_t, 0, "AuxRoiAutoExposure", False)
+            gen.add("aux_roi_auto_exposure_x", int_t, 0, "AuxRoiAutoExposureX", 0, 0, 1920)
+            gen.add("aux_roi_auto_exposure_y", int_t, 0, "AuxRoiAutoExposureY", 0, 0, 1188)
+            gen.add("aux_roi_auto_exposure_width", int_t, 0, "AuxRoiAutoExposureWidth", 0, 0, 1920)
+            gen.add("aux_roi_auto_exposure_height", int_t, 0, "AuxRoiAutoExposureHeight", 0, 0, 1188)
         #endif
 
-        if roi_width is not None and roi_height is not None:
-            gen.add("roi_auto_exposure", bool_t, 0, "RoiAutoExposure", False)
-            gen.add("roi_auto_exposure_x", int_t, 0, "RoiAutoExposureX", 0, 0, roi_width)
-            gen.add("roi_auto_exposure_y", int_t, 0, "RoiAutoExposureY", 0, 0, roi_height)
-            gen.add("roi_auto_exposure_width", int_t, 0, "RoiAutoExposureWidth", 0, 0, roi_width)
-            gen.add("roi_auto_exposure_height", int_t, 0, "RoiAutoExposureHeight", 0, 0, roi_height)
-    #endif
-
-    if cfg.aux:
-        gen.add("auto_white_balance", bool_t, 0, "AutoWhiteBalance", True)
-        gen.add("auto_white_balance_decay", int_t, 0, "AutoWhiteBalanceDecay", 3, 0, 20)
-        gen.add("auto_white_balance_thresh", double_t, 0, "AutoWhiteBalanceThresh", 0.5, 0.0, 1.0)
-        gen.add("white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
-        gen.add("white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
-
-        gen.add("enable_aux_controls", bool_t, 0, "AuxSensorControls", False)
-        gen.add("aux_gain", double_t, 0, "AuxSensorGain", 1.0, 1.0, 8.0)
-        gen.add("aux_auto_exposure", bool_t, 0, "AuxAutoExposure", True)
-        gen.add("aux_auto_exposure_max_time", double_t, 0, "AuxAutoExposureMaxTime", 0.5, 0.0, 0.5);
-        gen.add("aux_auto_exposure_decay", int_t, 0, "AuxAutoExposureDecay", 7, 0, 20)
-        gen.add("aux_auto_exposure_thresh", double_t, 0, "AuxAutoExposureThresh", auto_exposure_threshold, 0.0, 1.0)
-        gen.add("aux_auto_exposure_target_intensity", double_t, 0, "AuxAutoExposureTargetIntensity", 0.5, 0.0, 1.0)
-        gen.add("aux_exposure_time", double_t, 0, "AuxExposure", 0.025, 0, 0.5)
-        gen.add("aux_roi_auto_exposure", bool_t, 0, "AuxRoiAutoExposure", False)
-        gen.add("aux_roi_auto_exposure_x", int_t, 0, "AuxRoiAutoExposureX", 0, 0, 1920)
-        gen.add("aux_roi_auto_exposure_y", int_t, 0, "AuxRoiAutoExposureY", 0, 0, 1188)
-        gen.add("aux_roi_auto_exposure_width", int_t, 0, "AuxRoiAutoExposureWidth", 0, 0, 1920)
-        gen.add("aux_roi_auto_exposure_height", int_t, 0, "AuxRoiAutoExposureHeight", 0, 0, 1188)
-    #endif
-
-    if cfg.sgm:
-        gen.add("stereo_post_filtering", double_t, 0, "StereoPostFilterStrength", 0.75, 0.0, 1.0);
-    #endif
+        if cfg.sgm:
+            gen.add("stereo_post_filtering", double_t, 0, "StereoPostFilterStrength", 0.75, 0.0, 1.0);
+        #endif
 
 
-    if cfg.lighting:
-        gen.add("lighting", bool_t, 0, "Lighting", False)
-        gen.add("flash", bool_t, 0, "Flash", False)
-        gen.add("led_duty_cycle", double_t, 0, "DutyCycle", 0.0, 0.0, 1.0)
-    #endif
+        if cfg.lighting:
+            gen.add("lighting", bool_t, 0, "Lighting", False)
+            gen.add("flash", bool_t, 0, "Flash", False)
+            gen.add("led_duty_cycle", double_t, 0, "DutyCycle", 0.0, 0.0, 1.0)
+        #endif
 
-    if cfg.motor:
-        gen.add("motor_speed", double_t, 0, "MotorSpeed", 0.0, 0.0, 5.2);
-    #endif
+        if cfg.motor:
+            gen.add("motor_speed", double_t, 0, "MotorSpeed", 0.0, 0.0, 5.2);
+        #endif
 
-    gen.add("network_time_sync", bool_t, 0, "NetworkTimeSynchronization", True);
+        gen.add("network_time_sync", bool_t, 0, "NetworkTimeSynchronization", True);
 
-    if cfg.name.find('sgm_AR0234') != -1:
-        gen.add("ptp_time_sync", bool_t, 0, "PTPTimeSynchronization", False);
-        trigger_source_enum = gen.enum([ gen.const("internal", int_t, 0, ""),
-                                         gen.const("ptp", int_t, 3, "")],
-                                         "Trigger sources");
-        gen.add("trigger_source", int_t, 0, "Trigger Source", 0, edit_method=trigger_source_enum)
+        if cfg.name.find('sgm_AR0234') != -1:
+            gen.add("ptp_time_sync", bool_t, 0, "PTPTimeSynchronization", False);
+            trigger_source_enum = gen.enum([ gen.const("internal", int_t, 0, ""),
+                                            gen.const("ptp", int_t, 3, "")],
+                                            "Trigger sources");
+            gen.add("trigger_source", int_t, 0, "Trigger Source", 0, edit_method=trigger_source_enum)
 
-        gen.add("detail_disparity_profile", bool_t, 0, "DetailDisparityProfile", False);
-        gen.add("high_contrast_profile", bool_t, 0, "HighContrastProfile", False);
-        gen.add("show_roi_profile", bool_t, 0, "ShowRoiProfile", False);
-        gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
-        gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
-    #endif
+            gen.add("detail_disparity_profile", bool_t, 0, "DetailDisparityProfile", False);
+            gen.add("high_contrast_profile", bool_t, 0, "HighContrastProfile", False);
+            gen.add("show_roi_profile", bool_t, 0, "ShowRoiProfile", False);
+            gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
 
-    if cfg.imu:
-        gen.add("imu_samples_per_message", int_t, 0, "ImuSamplesPerMessage", 30, 1, 300)
-        gen.add("accelerometer_enabled", bool_t, 0, "AcceleromterEnabled", True)
-        a_rate_enum = gen.enum([ gen.const("10Hz__1HzCutoff", int_t, 0, ""),
-                                 gen.const("25Hz__3HzCutoff", int_t, 1, ""),
-                                 gen.const("50Hz__6HzCutoff", int_t, 2, ""),
-                                 gen.const("100Hz__11HzCutoff", int_t, 3, ""),
-                                 gen.const("200Hz__22HzCutoff", int_t, 4, ""),
-                                 gen.const("400Hz__44HzCutoff", int_t, 5, ""),
-                                 gen.const("1344Hz__150HzCutoff", int_t, 6, "") ],
-                               "Available accelerometer rates")
-        gen.add("accelerometer_rate", int_t, 0, "Accelerometer Rate", 3, edit_method=a_rate_enum)
-        a_range_enum = gen.enum([ gen.const("2g__1mg_per_lsb", int_t, 0, ""),
-                                  gen.const("4g__2mg_per_lsb", int_t, 1, ""),
-                                  gen.const("8g__4mg_per_lsb", int_t, 2, ""),
-                                  gen.const("16g__12mg_per_lsb", int_t, 3, "") ],
-                                "Available acceleromter ranges")
-        gen.add("accelerometer_range", int_t, 0, "Acceleromter Range", 0, edit_method=a_range_enum)
-        gen.add("gyroscope_enabled", bool_t, 0, "GyroscopeEnabled", True)
-        g_rate_enum = gen.enum([ gen.const("100Hz__13HzCutoff", int_t, 0, ""),
-                                 gen.const("200Hz__13HzCutoff", int_t, 1, ""),
-                                 gen.const("200Hz__25HzCutoff", int_t, 2, ""),
-                                 gen.const("400Hz__25HzCutoff", int_t, 3, ""),
-                                 gen.const("400Hz__50HzCutoff", int_t, 4, ""),
-                                 gen.const("800Hz__50HzCutoff", int_t, 5, ""),
-                                 gen.const("800Hz__110HzCutoff", int_t, 6, "") ],
-                               "Available gyroscope rates")
-        gen.add("gyroscope_rate", int_t, 0, "Gyroscope Rate", 3, edit_method=g_rate_enum)
-        g_range_enum = gen.enum([ gen.const("250dps__9mdps_per_lsb", int_t, 0, ""),
-                                  gen.const("500dps__18mdps_per_lsb", int_t, 1, ""),
-                                  gen.const("2000dps__70mdps_per_lsb", int_t, 2, "") ], "Available gyroscope ranges")
-        gen.add("gyroscope_range", int_t, 0, "Gyroscope Range", 0, edit_method=g_range_enum)
-        gen.add("magnetometer_enabled", bool_t, 0, "MagnetometerEnabled", True)
-        m_rate_enum = gen.enum([ gen.const("10Hz", int_t, 0, ""),
-                                 gen.const("25Hz", int_t, 1, ""),
-                                 gen.const("50Hz", int_t, 2, ""),
-                                 gen.const("100Hz", int_t, 3, "") ],
-                               "Available magnetometer rates")
-        gen.add("magnetometer_rate", int_t, 0, "Magnetometer Rate", 0, edit_method=m_rate_enum)
-        m_range_enum = gen.enum([ gen.const("1p3gauss__1020ugauss_per_lsb", int_t, 0, ""),
-                                  gen.const("1p9gauss__1316ugauss_per_lsb", int_t, 1, ""),
-                                  gen.const("2p5gauss__1667ugauss_per_lsb", int_t, 2, ""),
-                                  gen.const("4p0gauss__2500ugauss_per_lsb", int_t, 3, ""),
-                                  gen.const("4p7gauss__2817ugauss_per_lsb", int_t, 4, ""),
-                                  gen.const("5p6gauss__3390ugauss_per_lsb", int_t, 5, ""),
-                                  gen.const("8p1gauss__4878ugauss_per_lsb", int_t, 6, "") ],
-                                "Available magnetometer ranges")
-        gen.add("magnetometer_range", int_t, 0, "Magnetometer Range", 0, edit_method=m_range_enum);
-    #endif
+            if feature == SupportedFeatures.GROUND_SURFACE:
+                gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
+            #endif
+        #endif
 
-    clipping_enum = gen.enum([ gen.const("None", int_t, 0, "No Border Clip"),
-                               gen.const("Rectangular", int_t, 1, "Rectangular Border Clip"),
-                               gen.const("Circular", int_t, 2, "Circular Border Clip")],
-                              "Available border clipping options")
+        if cfg.imu:
+            gen.add("imu_samples_per_message", int_t, 0, "ImuSamplesPerMessage", 30, 1, 300)
+            gen.add("accelerometer_enabled", bool_t, 0, "AcceleromterEnabled", True)
+            a_rate_enum = gen.enum([ gen.const("10Hz__1HzCutoff", int_t, 0, ""),
+                                    gen.const("25Hz__3HzCutoff", int_t, 1, ""),
+                                    gen.const("50Hz__6HzCutoff", int_t, 2, ""),
+                                    gen.const("100Hz__11HzCutoff", int_t, 3, ""),
+                                    gen.const("200Hz__22HzCutoff", int_t, 4, ""),
+                                    gen.const("400Hz__44HzCutoff", int_t, 5, ""),
+                                    gen.const("1344Hz__150HzCutoff", int_t, 6, "") ],
+                                "Available accelerometer rates")
+            gen.add("accelerometer_rate", int_t, 0, "Accelerometer Rate", 3, edit_method=a_rate_enum)
+            a_range_enum = gen.enum([ gen.const("2g__1mg_per_lsb", int_t, 0, ""),
+                                    gen.const("4g__2mg_per_lsb", int_t, 1, ""),
+                                    gen.const("8g__4mg_per_lsb", int_t, 2, ""),
+                                    gen.const("16g__12mg_per_lsb", int_t, 3, "") ],
+                                    "Available acceleromter ranges")
+            gen.add("accelerometer_range", int_t, 0, "Acceleromter Range", 0, edit_method=a_range_enum)
+            gen.add("gyroscope_enabled", bool_t, 0, "GyroscopeEnabled", True)
+            g_rate_enum = gen.enum([ gen.const("100Hz__13HzCutoff", int_t, 0, ""),
+                                    gen.const("200Hz__13HzCutoff", int_t, 1, ""),
+                                    gen.const("200Hz__25HzCutoff", int_t, 2, ""),
+                                    gen.const("400Hz__25HzCutoff", int_t, 3, ""),
+                                    gen.const("400Hz__50HzCutoff", int_t, 4, ""),
+                                    gen.const("800Hz__50HzCutoff", int_t, 5, ""),
+                                    gen.const("800Hz__110HzCutoff", int_t, 6, "") ],
+                                "Available gyroscope rates")
+            gen.add("gyroscope_rate", int_t, 0, "Gyroscope Rate", 3, edit_method=g_rate_enum)
+            g_range_enum = gen.enum([ gen.const("250dps__9mdps_per_lsb", int_t, 0, ""),
+                                    gen.const("500dps__18mdps_per_lsb", int_t, 1, ""),
+                                    gen.const("2000dps__70mdps_per_lsb", int_t, 2, "") ], "Available gyroscope ranges")
+            gen.add("gyroscope_range", int_t, 0, "Gyroscope Range", 0, edit_method=g_range_enum)
+            gen.add("magnetometer_enabled", bool_t, 0, "MagnetometerEnabled", True)
+            m_rate_enum = gen.enum([ gen.const("10Hz", int_t, 0, ""),
+                                    gen.const("25Hz", int_t, 1, ""),
+                                    gen.const("50Hz", int_t, 2, ""),
+                                    gen.const("100Hz", int_t, 3, "") ],
+                                "Available magnetometer rates")
+            gen.add("magnetometer_rate", int_t, 0, "Magnetometer Rate", 0, edit_method=m_rate_enum)
+            m_range_enum = gen.enum([ gen.const("1p3gauss__1020ugauss_per_lsb", int_t, 0, ""),
+                                    gen.const("1p9gauss__1316ugauss_per_lsb", int_t, 1, ""),
+                                    gen.const("2p5gauss__1667ugauss_per_lsb", int_t, 2, ""),
+                                    gen.const("4p0gauss__2500ugauss_per_lsb", int_t, 3, ""),
+                                    gen.const("4p7gauss__2817ugauss_per_lsb", int_t, 4, ""),
+                                    gen.const("5p6gauss__3390ugauss_per_lsb", int_t, 5, ""),
+                                    gen.const("8p1gauss__4878ugauss_per_lsb", int_t, 6, "") ],
+                                    "Available magnetometer ranges")
+            gen.add("magnetometer_range", int_t, 0, "Magnetometer Range", 0, edit_method=m_range_enum);
+        #endif
 
-    if "4000" in cfg.name:
-        clipping_max = 400.0
-    else:
-        clipping_max = 200.0
-    #endif
+        clipping_enum = gen.enum([ gen.const("None", int_t, 0, "No Border Clip"),
+                                gen.const("Rectangular", int_t, 1, "Rectangular Border Clip"),
+                                gen.const("Circular", int_t, 2, "Circular Border Clip")],
+                                "Available border clipping options")
 
-    gen.add("border_clip_type", int_t, 0, "point cloud border clip type", 0, 0, 2, edit_method=clipping_enum)
-    gen.add("border_clip_value", double_t, 0, "point cloud border clip value", 0.0, 0.0, clipping_max)
+        if "4000" in cfg.name:
+            clipping_max = 400.0
+        else:
+            clipping_max = 200.0
+        #endif
 
-    gen.add("max_point_cloud_range", double_t, 0, "max point cloud range", 15.0, 0.0, 100.0)
+        gen.add("border_clip_type", int_t, 0, "point cloud border clip type", 0, 0, 2, edit_method=clipping_enum)
+        gen.add("border_clip_value", double_t, 0, "point cloud border clip value", 0.0, 0.0, clipping_max)
 
-    gen.add("origin_from_camera_position_x_m", double_t, 0, "Origin from camera extrinsics transform x value (m)", 0.0, -100.0, 100.0)
-    gen.add("origin_from_camera_position_y_m", double_t, 0, "Origin from camera extrinsics transform y value (m)", 0.0, -100.0, 100.0)
-    gen.add("origin_from_camera_position_z_m", double_t, 0, "Origin from camera extrinsics transform z value (m)", 0.0, -100.0, 100.0)
-    gen.add("origin_from_camera_rotation_x_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation x (deg)", 0.0, -180.0, 180.0)
-    gen.add("origin_from_camera_rotation_y_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation y (deg)", 0.0, -180.0, 180.0)
-    gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
+        gen.add("max_point_cloud_range", double_t, 0, "max point cloud range", 15.0, 0.0, 100.0)
 
-    gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
-    gen.add("ground_surface_pointcloud_global_max_z_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_global_min_z_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.5, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_global_max_x_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_global_min_x_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
-    gen.add("ground_surface_pointcloud_global_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
-    gen.add("ground_surface_pointcloud_global_min_height_m", double_t, 0, "Minimum pointcloud height for B-spline fit", -10.0, -50.0, 0.0)
-    gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)
-    gen.add("ground_surface_spline_resolution_z", int_t, 0, "Number of spline levels in the left camera optical frame's z dimension", 4, 0, 10)
-    base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),
-                        gen.const("Mean", str_t, "Mean", "Mean"),
-                        gen.const("Zero", str_t, "Zero", "Zero")],
-                        "Available base model settings");
-    gen.add("ground_surface_pre_transform_data", str_t, 0, "Model to transform raw data with before performing B-Spline fit", "Mean", edit_method=base_model_enum);
+        gen.add("origin_from_camera_position_x_m", double_t, 0, "Origin from camera extrinsics transform x value (m)", 0.0, -100.0, 100.0)
+        gen.add("origin_from_camera_position_y_m", double_t, 0, "Origin from camera extrinsics transform y value (m)", 0.0, -100.0, 100.0)
+        gen.add("origin_from_camera_position_z_m", double_t, 0, "Origin from camera extrinsics transform z value (m)", 0.0, -100.0, 100.0)
+        gen.add("origin_from_camera_rotation_x_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation x (deg)", 0.0, -180.0, 180.0)
+        gen.add("origin_from_camera_rotation_y_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation y (deg)", 0.0, -180.0, 180.0)
+        gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
 
-    gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled  upon — larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
-    gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process — used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
-    gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "Obstacle height in meters", 2.0, 0.0, 10.0)
-    gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "Percentage of points in XZ cell column which must be above obstacle height threshold to consider the cell an obstacle", 0.50, 0.0, 1.0)
-    gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)
-    gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "ADVANCED SETTING: Border size around obstacle cells to examine during iterative B-spline routine", 1.5, 0.0, 5.0)
-    gen.add("ground_surface_spline_draw_resolution", double_t, 0, "Resolution to draw resulting B-Spline model with in RVIZ", 0.1, 0.01, 1.0)
+        if feature == SupportedFeatures.GROUND_SURFACE:
+            gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
+            gen.add("ground_surface_pointcloud_global_max_z_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
+            gen.add("ground_surface_pointcloud_global_min_z_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.5, 0.0, 50.0)
+            gen.add("ground_surface_pointcloud_global_max_x_m", double_t, 0, "Maximum pointcloud width (LHS distance) for B-spline fit", 25.0, 0.0, 50.0)
+            gen.add("ground_surface_pointcloud_global_min_x_m", double_t, 0, "Minimum pointcloud width (LHS distance) for B-spline fit", -25.0, -50.0, 0.0)
+            gen.add("ground_surface_pointcloud_global_max_height_m", double_t, 0, "Maximum pointcloud height for B-spline fit", 10.0, 0.0, 50.0)
+            gen.add("ground_surface_pointcloud_global_min_height_m", double_t, 0, "Minimum pointcloud height for B-spline fit", -10.0, -50.0, 0.0)
+            gen.add("ground_surface_spline_resolution_x", int_t, 0, "Number of spline levels in the left camera optical frame's x dimension", 4, 0, 10)
+            gen.add("ground_surface_spline_resolution_z", int_t, 0, "Number of spline levels in the left camera optical frame's z dimension", 4, 0, 10)
+            base_model_enum = gen.enum([gen.const("Quadratic", str_t, "Quadratic", "Quadratic"),
+                                gen.const("Mean", str_t, "Mean", "Mean"),
+                                gen.const("Zero", str_t, "Zero", "Zero")],
+                                "Available base model settings");
+            gen.add("ground_surface_pre_transform_data", str_t, 0, "Model to transform raw data with before performing B-Spline fit", "Mean", edit_method=base_model_enum);
 
-    gen.generate(PACKAGE, cfg.name, cfg.name)
+            gen.add("ground_surface_pointcloud_grid_size", double_t, 0, "Size of XZ cells which the B-Spline is modelled  upon — larger cell sizes result in faster processing and coarser models", 0.5, 0.01, 1.0)
+            gen.add("ground_surface_min_points_per_grid", int_t, 0, "For each XZ cell column, there must be at least this many points in order to use the centroid in the B-spline modelling process — used to filter extranoues & noisy points from influencing B-spline model", 10, 0, 100)
+            gen.add("ground_surface_obstacle_height_thresh_m", double_t, 0, "Obstacle height in meters", 2.0, 0.0, 10.0)
+            gen.add("ground_surface_obstacle_percentage_thresh", double_t, 0, "Percentage of points in XZ cell column which must be above obstacle height threshold to consider the cell an obstacle", 0.50, 0.0, 1.0)
+            gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)
+            gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "ADVANCED SETTING: Border size around obstacle cells to examine during iterative B-spline routine", 1.5, 0.0, 5.0)
+            gen.add("ground_surface_spline_draw_resolution", double_t, 0, "Resolution to draw resulting B-Spline model with in RVIZ", 0.1, 0.01, 1.0)
+        #endif
+
+        # Generate package name based on camera cfg and supported features
+        if feature == SupportedFeatures.NONE:
+            package_name = cfg.name
+        else:
+            package_name = cfg.name + "_" + feature_name.lower()
+
+        gen.generate(PACKAGE, package_name, package_name)
+    #endfor
 #endfor
 
 # BCAM

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -293,6 +293,7 @@ for cfg in sensorConfigList:
     gen.add("origin_from_camera_rotation_z_deg", double_t, 0, "Origin from camera extrinsics transform angle axis rotation z (deg)", 0.0, -180.0, 180.0)
 
     # Ground Surface Parameters
+    # TODO(drobinson): Restrinct visibilty to supported S27 / S30 cameras
     gen.add("ground_surface_pointcloud_decimation", int_t, 0, "Disparity image decimation for B-spline fit. Values above 1 significantly decrease processing time.", 1, 1, 4)
     gen.add("ground_surface_pointcloud_max_range_m", double_t, 0, "Maximum pointcloud range for B-spline fit", 30.0, 0.0, 50.0)
     gen.add("ground_surface_pointcloud_min_range_m", double_t, 0, "Minimum pointcloud range for B-spline fit", 0.0, 0.0, 50.0)

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -84,8 +84,8 @@ public:
 
     void extrinsicsChanged(crl::multisense::system::ExternalCalibration extrinsics);
 
-    void groundSurfaceSplineResolutionChanged(
-        const ground_surface_utilities::SplineDrawingParams &spline_params);
+    void groundSurfaceSplineDrawParametersChanged(
+        const ground_surface_utilities::SplineDrawParameters &spline_draw_params);
 
 private:
     //
@@ -333,7 +333,7 @@ private:
     //
     // Parameters for drawing ground surface spline
 
-    ground_surface_utilities::SplineDrawingParams spline_params_;
+    ground_surface_utilities::SplineDrawParameters spline_draw_params_;
 
     //
     // Storage of images which we use for pointcloud colorizing

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -83,7 +83,12 @@ public:
 
     void extrinsicsChanged(crl::multisense::system::ExternalCalibration extrinsics);
 
-    void groundSurfaceSplineResolutionChanged(double ground_surface_spline_resolution);
+    void groundSurfaceSplineResolutionChanged(
+        double ground_surface_spline_resolution,
+        double ground_surface_pointcloud_global_max_z_m,
+        double ground_surface_pointcloud_global_min_z_m,
+        double ground_surface_pointcloud_global_max_x_m,
+        double ground_surface_pointcloud_global_min_x_m);
 
 private:
     //
@@ -332,6 +337,10 @@ private:
     // Resolution to draw ground surface spline
 
     double ground_surface_spline_resolution_ = 0.1;
+    double ground_surface_pointcloud_global_max_z_m_;
+    double ground_surface_pointcloud_global_min_z_m_;
+    double ground_surface_pointcloud_global_max_x_m_;
+    double ground_surface_pointcloud_global_min_x_m_;
 
     //
     // Storage of images which we use for pointcloud colorizing

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -53,6 +53,7 @@
 #include <multisense_lib/MultiSenseChannel.hh>
 #include <multisense_ros/RawCamData.h>
 #include <multisense_ros/camera_utilities.h>
+#include <multisense_ros/ground_surface_utilities.h>
 
 namespace multisense_ros {
 
@@ -84,11 +85,7 @@ public:
     void extrinsicsChanged(crl::multisense::system::ExternalCalibration extrinsics);
 
     void groundSurfaceSplineResolutionChanged(
-        double ground_surface_spline_resolution,
-        double ground_surface_pointcloud_global_max_z_m,
-        double ground_surface_pointcloud_global_min_z_m,
-        double ground_surface_pointcloud_global_max_x_m,
-        double ground_surface_pointcloud_global_min_x_m);
+        const ground_surface_utilities::SplineDrawingParams &spline_params);
 
 private:
     //
@@ -334,13 +331,9 @@ private:
     double border_clip_value_ = 0.0;
 
     //
-    // Resolution to draw ground surface spline
+    // Parameters for drawing ground surface spline
 
-    double ground_surface_spline_resolution_ = 0.1;
-    double ground_surface_pointcloud_global_max_z_m_;
-    double ground_surface_pointcloud_global_min_z_m_;
-    double ground_surface_pointcloud_global_max_x_m_;
-    double ground_surface_pointcloud_global_min_x_m_;
+    ground_surface_utilities::SplineDrawingParams spline_params_;
 
     //
     // Storage of images which we use for pointcloud colorizing

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -83,6 +83,8 @@ public:
 
     void extrinsicsChanged(crl::multisense::system::ExternalCalibration extrinsics);
 
+    void groundSurfaceSplineResolutionChanged(double ground_surface_spline_resolution);
+
 private:
     //
     // Node names
@@ -325,6 +327,11 @@ private:
 
     BorderClip border_clip_type_ = BorderClip::NONE;
     double border_clip_value_ = 0.0;
+
+    //
+    // Resolution to draw ground surface spline
+
+    double ground_surface_spline_resolution_ = 0.1;
 
     //
     // Storage of images which we use for pointcloud colorizing

--- a/multisense_ros/include/multisense_ros/ground_surface_utilities.h
+++ b/multisense_ros/include/multisense_ros/ground_surface_utilities.h
@@ -76,7 +76,13 @@ std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertS
     const float* xzCellOrigin,
     const float* xzCellSize,
     const float* xzLimit,
+    double ground_surface_pointcloud_global_max_z_m,
+    double ground_surface_pointcloud_global_min_z_m,
+    double ground_surface_pointcloud_global_max_x_m,
+    double ground_surface_pointcloud_global_min_x_m,
+    double pointcloud_max_range,
     const float* minMaxAzimuthAngle,
+    const float* extrinsics,
     const float* quadraticParams,
     const float baseline,
     const double drawResolution);

--- a/multisense_ros/include/multisense_ros/ground_surface_utilities.h
+++ b/multisense_ros/include/multisense_ros/ground_surface_utilities.h
@@ -67,11 +67,20 @@ sensor_msgs::PointCloud2 eigenToPointcloud(
 ///
 struct SplineDrawParameters
 {
-    double max_z_m;
-    double min_z_m;
-    double max_x_m;
-    double min_x_m;
-    double resolution;
+    /// @brief The max range (along the z dimension / optical axis) to draw the B-spline model
+    double max_z_m = 30.0;
+
+    /// @brief The min range (along the z dimension / optical axis) to draw the B-spline model
+    double min_z_m = 0.5;
+
+    /// @brief The max width (along the x dimension) to draw the B-spline model
+    double max_x_m = 25.0;
+
+    /// @brief The min width (along the x dimension) to draw the B-spline model
+    double min_x_m = -25.0;
+
+    /// @brief The resolution to sample the B-Spline model for drawing
+    double resolution = 0.1;
 };
 
 ///

--- a/multisense_ros/include/multisense_ros/ground_surface_utilities.h
+++ b/multisense_ros/include/multisense_ros/ground_surface_utilities.h
@@ -65,7 +65,7 @@ sensor_msgs::PointCloud2 eigenToPointcloud(
 ///
 /// @brief Struct containing parameters for drawing a pointcloud representation of a B-Spline model
 ///
-struct SplineDrawingParams
+struct SplineDrawParameters
 {
     double max_z_m;
     double min_z_m;
@@ -77,7 +77,7 @@ struct SplineDrawingParams
 ///
 /// @brief Generate a pointcloud representation of a b-spline ground surface model for visualization
 /// @param controlGrid Control points grid used to determine interpolated spline values
-/// @param splineParams Parameters for drawing a pointcloud representation of a B-Spline model
+/// @param splineDrawParams Parameters for drawing a pointcloud representation of a B-Spline model
 /// @param pointcloudMaxRange Max range to draw spline model to from camera frame
 /// @param xzCellOrigin X,Z cell origin of the spline fitting algorithm in meters
 /// @param xzCellSize Size of the X,Z plane containing the spline fit in meters
@@ -89,7 +89,7 @@ struct SplineDrawingParams
 ///
 std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertSplineToPointcloud(
     const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &controlGrid,
-    const SplineDrawingParams &splineParams,
+    const SplineDrawParameters &splineDrawParams,
     const double pointcloudMaxRange,
     const float* xzCellOrigin,
     const float* xzCellSize,

--- a/multisense_ros/include/multisense_ros/ground_surface_utilities.h
+++ b/multisense_ros/include/multisense_ros/ground_surface_utilities.h
@@ -68,6 +68,7 @@ sensor_msgs::PointCloud2 eigenToPointcloud(
 /// @param minMaxAzimuthAngle Min and max limit to the spline fitting angle in radians, for visualization purposes
 /// @param quadraticParams parameters for the quadratic data transformation prior to spline fitting
 /// @param baseline Stereo camera baseline in meters
+/// @param drawResolution Resolution to draw the spline ground surface with in RVIZ
 /// @return Eigen representation of spline pointcloud at regularly sample x/z intervals
 ///`
 std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertSplineToPointcloud(
@@ -77,6 +78,7 @@ std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertS
     const float* xzLimit,
     const float* minMaxAzimuthAngle,
     const float* quadraticParams,
-    const float baseline);
+    const float baseline,
+    const double drawResolution);
 
 } // namespace ground_surface_utilities

--- a/multisense_ros/include/multisense_ros/ground_surface_utilities.h
+++ b/multisense_ros/include/multisense_ros/ground_surface_utilities.h
@@ -31,6 +31,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **/
 
+#ifndef MULTISENSE_ROS_GROUND_SURFACE_UTILITIES_H
+#define MULTISENSE_ROS_GROUND_SURFACE_UTILITIES_H
+
 #include <vector>
 #include <numeric>
 
@@ -60,31 +63,41 @@ sensor_msgs::PointCloud2 eigenToPointcloud(
     const std::string &frame_id);
 
 ///
+/// @brief Struct containing parameters for drawing a pointcloud representation of a B-Spline model
+///
+struct SplineDrawingParams
+{
+    double max_z_m;
+    double min_z_m;
+    double max_x_m;
+    double min_x_m;
+    double resolution;
+};
+
+///
 /// @brief Generate a pointcloud representation of a b-spline ground surface model for visualization
 /// @param controlGrid Control points grid used to determine interpolated spline values
+/// @param splineParams Parameters for drawing a pointcloud representation of a B-Spline model
+/// @param pointcloudMaxRange Max range to draw spline model to from camera frame
 /// @param xzCellOrigin X,Z cell origin of the spline fitting algorithm in meters
 /// @param xzCellSize Size of the X,Z plane containing the spline fit in meters
-/// @param xzLimit X,Z limit to the spline fitting area in meters
 /// @param minMaxAzimuthAngle Min and max limit to the spline fitting angle in radians, for visualization purposes
+/// @param extrinsics Extrinsic transform for stereo pointcloud used during B-Spline modelling
 /// @param quadraticParams parameters for the quadratic data transformation prior to spline fitting
 /// @param baseline Stereo camera baseline in meters
-/// @param drawResolution Resolution to draw the spline ground surface with in RVIZ
 /// @return Eigen representation of spline pointcloud at regularly sample x/z intervals
-///`
+///
 std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertSplineToPointcloud(
     const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &controlGrid,
+    const SplineDrawingParams &splineParams,
+    const double pointcloudMaxRange,
     const float* xzCellOrigin,
     const float* xzCellSize,
-    const float* xzLimit,
-    double ground_surface_pointcloud_global_max_z_m,
-    double ground_surface_pointcloud_global_min_z_m,
-    double ground_surface_pointcloud_global_max_x_m,
-    double ground_surface_pointcloud_global_min_x_m,
-    double pointcloud_max_range,
     const float* minMaxAzimuthAngle,
     const float* extrinsics,
     const float* quadraticParams,
-    const float baseline,
-    const double drawResolution);
+    const float baseline);
 
 } // namespace ground_surface_utilities
+
+#endif

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -108,7 +108,6 @@ private:
     template<class T> void configurePointCloudRange(const T& dyn);
     template<class T> void configurePtp(const T& dyn);
     template<class T> void configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn);
-    template<class T> void configureStereoProfileWithGroundSurface(crl::multisense::image::Config &cfg, const T& dyn);
     template<class T> void configureExtrinsics(const T& dyn);
     template<class T> void configureGroundSurfaceParams(const T& dyn);
 

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -105,6 +105,7 @@ private:
     template<class T> void configurePtp(const T& dyn);
     template<class T> void configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn);
     template<class T> void configureExtrinsics(const T& dyn);
+    template<class T> void configureGroundSurfaceParams(const T& dyn);
 
     //
     // CRL sensor API

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -52,7 +52,9 @@
 #include <multisense_ros/mono_cmv2000Config.h>
 #include <multisense_ros/mono_cmv4000Config.h>
 #include <multisense_ros/s27_sgm_AR0234Config.h>
+#include <multisense_ros/s27_sgm_AR0234_ground_surfaceConfig.h>
 #include <multisense_ros/ks21_sgm_AR0234Config.h>
+#include <multisense_ros/ks21_sgm_AR0234_ground_surfaceConfig.h>
 #include <multisense_ros/camera_utilities.h>
 #include <multisense_ros/ground_surface_utilities.h>
 
@@ -90,6 +92,9 @@ private:
     void callback_s27_AR0234        (multisense_ros::s27_sgm_AR0234Config&     config, uint32_t level);
     void callback_ks21_AR0234       (multisense_ros::ks21_sgm_AR0234Config&    config, uint32_t level);
 
+    void callback_s27_AR0234_ground_surface        (multisense_ros::s27_sgm_AR0234_ground_surfaceConfig&     dyn, uint32_t level);
+    void callback_ks21_AR0234_ground_surface       (multisense_ros::ks21_sgm_AR0234_ground_surfaceConfig&    dyn, uint32_t level);
+
     //
     // Internal helper functions
 
@@ -108,6 +113,7 @@ private:
     template<class T> void configurePointCloudRange(const T& dyn);
     template<class T> void configurePtp(const T& dyn);
     template<class T> void configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn);
+    template<class T> void configureStereoProfileWithGroundSurface(crl::multisense::image::Config &cfg, const T& dyn);
     template<class T> void configureExtrinsics(const T& dyn);
     template<class T> void configureGroundSurfaceParams(const T& dyn);
 
@@ -147,7 +153,9 @@ private:
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::mono_cmv2000Config> >       server_mono_cmv2000_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::mono_cmv4000Config> >       server_mono_cmv4000_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::s27_sgm_AR0234Config> >     server_s27_AR0234_;
-    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234Config> >    server_ks21_sgm_AR0234;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234Config> >    server_ks21_sgm_AR0234_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::s27_sgm_AR0234_ground_surfaceConfig> >     server_s27_AR0234_ground_surface_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234_ground_surfaceConfig> >    server_ks21_sgm_AR0234_ground_surface_;
 
     //
     // Cached values for supported sub-systems (these may be unavailable on

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -107,6 +107,7 @@ private:
     template<class T> void configurePointCloudRange(const T& dyn);
     template<class T> void configurePtp(const T& dyn);
     template<class T> void configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn);
+    template<class T> void configureStereoProfileWithGroundSurface(crl::multisense::image::Config &cfg, const T& dyn);
     template<class T> void configureExtrinsics(const T& dyn);
     template<class T> void configureGroundSurfaceParams(const T& dyn);
 

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -66,7 +66,7 @@ public:
                 std::function<void (BorderClip, double)> borderClipChangeCallback,
                 std::function<void (double)> maxPointCloudRangeCallback,
                 std::function<void (crl::multisense::system::ExternalCalibration)> extrinsicsCallback,
-                std::function<void (ground_surface_utilities::SplineDrawingParams)> groundSurfaceSplineResolutionCallback);
+                std::function<void (ground_surface_utilities::SplineDrawParameters)> groundSurfaceSplineDrawParametersCallback);
 
     ~Reconfigure();
 
@@ -185,7 +185,7 @@ private:
     //
     // Extrinsics callback to modify pointcloud
 
-    std::function<void (ground_surface_utilities::SplineDrawingParams)> ground_surface_spline_resolution_callback_;
+    std::function<void (ground_surface_utilities::SplineDrawParameters)> spline_draw_parameters_callback_;
 };
 
 } // multisense_ros

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -65,7 +65,7 @@ public:
                 std::function<void (BorderClip, double)> borderClipChangeCallback,
                 std::function<void (double)> maxPointCloudRangeCallback,
                 std::function<void (crl::multisense::system::ExternalCalibration)> extrinsicsCallback,
-                std::function<void (double)> groundSurfaceSplineResolutionCallback);
+                std::function<void (double, double, double, double, double)> groundSurfaceSplineResolutionCallback);
 
     ~Reconfigure();
 
@@ -202,7 +202,7 @@ private:
     //
     // Extrinsics callback to modify pointcloud
 
-    std::function<void (double)> ground_surface_spline_resolution_callback_;
+    std::function<void (double, double, double, double, double)> ground_surface_spline_resolution_callback_;
 };
 
 } // multisense_ros

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -113,23 +113,6 @@ private:
     template<class T> void configureGroundSurfaceParams(const T& dyn);
 
     //
-    // Mutex to allow multiple callbacks to write to camera flash
-
-    std::mutex flash_write_;
-
-    //
-    // Internal copy of calibration values to check whether they've changed in callbacks
-
-    bool external_calibration_retrieved_from_flash_;
-    crl::multisense::system::ExternalCalibration calibration_;
-
-    //
-    // Internal copy of ground surface params to check whether they've changed in callbacks
-
-    bool ground_surface_params_retrieved_from_flash_;
-    crl::multisense::system::GroundSurfaceParams params_;
-
-    //
     // CRL sensor API
 
     crl::multisense::Channel* driver_ = nullptr;

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -54,6 +54,7 @@
 #include <multisense_ros/s27_sgm_AR0234Config.h>
 #include <multisense_ros/ks21_sgm_AR0234Config.h>
 #include <multisense_ros/camera_utilities.h>
+#include <multisense_ros/ground_surface_utilities.h>
 
 namespace multisense_ros {
 
@@ -65,7 +66,7 @@ public:
                 std::function<void (BorderClip, double)> borderClipChangeCallback,
                 std::function<void (double)> maxPointCloudRangeCallback,
                 std::function<void (crl::multisense::system::ExternalCalibration)> extrinsicsCallback,
-                std::function<void (double, double, double, double, double)> groundSurfaceSplineResolutionCallback);
+                std::function<void (ground_surface_utilities::SplineDrawingParams)> groundSurfaceSplineResolutionCallback);
 
     ~Reconfigure();
 
@@ -202,7 +203,7 @@ private:
     //
     // Extrinsics callback to modify pointcloud
 
-    std::function<void (double, double, double, double, double)> ground_surface_spline_resolution_callback_;
+    std::function<void (ground_surface_utilities::SplineDrawingParams)> ground_surface_spline_resolution_callback_;
 };
 
 } // multisense_ros

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -807,10 +807,10 @@ void Camera::extrinsicsChanged(crl::multisense::system::ExternalCalibration extr
     static_tf_broadcaster_.sendTransform(extrinsic_transforms_);
 }
 
-void Camera::groundSurfaceSplineResolutionChanged(
-    const ground_surface_utilities::SplineDrawingParams &spline_params)
+void Camera::groundSurfaceSplineDrawParametersChanged(
+    const ground_surface_utilities::SplineDrawParameters &spline_draw_params)
 {
-    spline_params_ = spline_params;
+    spline_draw_params_ = spline_draw_params;
 }
 
 void Camera::histogramCallback(const image::Header& header)
@@ -2067,7 +2067,7 @@ void Camera::groundSurfaceSplineCallback(const ground_surface::Header& header)
     // Generate pointcloud for visualization
     auto eigen_pcl = ground_surface_utilities::convertSplineToPointcloud(
         controlGrid,
-        spline_params_,
+        spline_draw_params_,
         pointcloud_max_range_,
         header.xzCellOrigin,
         header.xzCellSize,

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -808,6 +808,11 @@ void Camera::extrinsicsChanged(crl::multisense::system::ExternalCalibration extr
     static_tf_broadcaster_.sendTransform(extrinsic_transforms_);
 }
 
+void Camera::groundSurfaceSplineResolutionChanged(double ground_surface_spline_resolution)
+{
+    ground_surface_spline_resolution_ = ground_surface_spline_resolution;
+}
+
 void Camera::histogramCallback(const image::Header& header)
 {
     if (last_frame_id_ >= header.frameId)
@@ -2062,11 +2067,12 @@ void Camera::groundSurfaceSplineCallback(const ground_surface::Header& header)
         header.xzLimit,
         minMaxAzimuthAngle,
         header.quadraticParams,
-        config.tx()
+        config.tx(),
+        ground_surface_spline_resolution_
     );
 
     // Send pointcloud message
-    ground_surface_spline_pub_.publish(ground_surface_utilities::eigenToPointcloud(eigen_pcl, frame_id_rectified_left_));
+    ground_surface_spline_pub_.publish(ground_surface_utilities::eigenToPointcloud(eigen_pcl, frame_id_origin_));
 }
 
 void Camera::updateConfig(const image::Config& config)

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -808,9 +808,18 @@ void Camera::extrinsicsChanged(crl::multisense::system::ExternalCalibration extr
     static_tf_broadcaster_.sendTransform(extrinsic_transforms_);
 }
 
-void Camera::groundSurfaceSplineResolutionChanged(double ground_surface_spline_resolution)
+void Camera::groundSurfaceSplineResolutionChanged(
+    double ground_surface_spline_resolution,
+    double ground_surface_pointcloud_global_max_z_m,
+    double ground_surface_pointcloud_global_min_z_m,
+    double ground_surface_pointcloud_global_max_x_m,
+    double ground_surface_pointcloud_global_min_x_m)
 {
     ground_surface_spline_resolution_ = ground_surface_spline_resolution;
+    ground_surface_pointcloud_global_max_z_m_ = ground_surface_pointcloud_global_max_z_m;
+    ground_surface_pointcloud_global_min_z_m_ = ground_surface_pointcloud_global_min_z_m;
+    ground_surface_pointcloud_global_max_x_m_ = ground_surface_pointcloud_global_max_x_m;
+    ground_surface_pointcloud_global_min_x_m_ = ground_surface_pointcloud_global_min_x_m;
 }
 
 void Camera::histogramCallback(const image::Header& header)
@@ -2070,7 +2079,13 @@ void Camera::groundSurfaceSplineCallback(const ground_surface::Header& header)
         header.xzCellOrigin,
         header.xzCellSize,
         header.xzLimit,
+        ground_surface_pointcloud_global_max_z_m_,
+        ground_surface_pointcloud_global_min_z_m_,
+        ground_surface_pointcloud_global_max_x_m_,
+        ground_surface_pointcloud_global_min_x_m_,
+        pointcloud_max_range_,
         minMaxAzimuthAngle,
+        header.extrinsics,
         header.quadraticParams,
         config.tx(),
         ground_surface_spline_resolution_

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -2043,8 +2043,13 @@ void Camera::groundSurfaceSplineCallback(const ground_surface::Header& header)
 {
     if (header.controlPointsBitsPerPixel != 32)
     {
-        std::cerr << "Expecting floats for spline control points, got " << header.controlPointsBitsPerPixel
-                  << " bits per pixel instead" << std::endl;
+        ROS_WARN("Expecting floats for spline control points, got %u bits per pixel instead", header.controlPointsBitsPerPixel);
+        return;
+    }
+
+    if (!header.success)
+    {
+        ROS_WARN("Ground surface modelling failed, consider modifying camera extrinsics and/or algorithm parameters");
         return;
     }
 

--- a/multisense_ros/src/ground_surface_utilities.cpp
+++ b/multisense_ros/src/ground_surface_utilities.cpp
@@ -205,7 +205,7 @@ sensor_msgs::PointCloud2 eigenToPointcloud(
 
 std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertSplineToPointcloud(
     const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> &controlGrid,
-    const SplineDrawingParams &splineParams,
+    const SplineDrawParameters &splineDrawParams,
     const double pointcloudMaxRange,
     const float* xzCellOrigin,
     const float* xzCellSize,
@@ -236,15 +236,15 @@ std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertS
 
     // Precompute number of points that will be drawn
     const size_t numPoints =
-        std::floor((splineParams.max_x_m - splineParams.min_x_m) / splineParams.resolution) *
-        std::floor((splineParams.max_z_m - splineParams.min_z_m) / splineParams.resolution);
+        std::floor((splineDrawParams.max_x_m - splineDrawParams.min_x_m) / splineDrawParams.resolution) *
+        std::floor((splineDrawParams.max_z_m - splineDrawParams.min_z_m) / splineDrawParams.resolution);
 
     std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> points;
     points.reserve(numPoints);
 
-    for (float x = splineParams.min_x_m; x < splineParams.max_x_m; x += splineParams.resolution)
+    for (float x = splineDrawParams.min_x_m; x < splineDrawParams.max_x_m; x += splineDrawParams.resolution)
     {
-        for (float z = splineParams.min_z_m; z < splineParams.max_z_m; z += splineParams.resolution)
+        for (float z = splineDrawParams.min_z_m; z < splineDrawParams.max_z_m; z += splineDrawParams.resolution)
         {
             // Compute spline point and transform into left camera optical frame
             const auto y = getSplineValue(xzCellOrigin, xzCellSize, x, z, controlGrid, basisArray)

--- a/multisense_ros/src/ground_surface_utilities.cpp
+++ b/multisense_ros/src/ground_surface_utilities.cpp
@@ -210,9 +210,9 @@ std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> convertS
     const float* xzLimit,
     const float* minMaxAzimuthAngle,
     const float* quadraticParams,
-    const float baseline)
+    const float baseline,
+    const double drawResolution)
 {
-    static constexpr double drawResolution = 0.1;
     static const auto basisArray = generateBasisArray();
 
     // Get boundaries of valid spline area

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -705,6 +705,17 @@ template<class T> void Reconfigure::configureStereoProfile(crl::multisense::imag
     profile |= (dyn.detail_disparity_profile ? crl::multisense::Detail_Disparity : profile);
     profile |= (dyn.high_contrast_profile ? crl::multisense::High_Contrast : profile);
     profile |= (dyn.show_roi_profile ? crl::multisense::Show_ROIs : profile);
+    profile |= (dyn.full_res_aux_profile ? crl::multisense::Full_Res_Aux_Cam : profile);
+
+    cfg.setCameraProfile(profile);
+}
+
+template<class T> void Reconfigure::configureStereoProfileWithGroundSurface(crl::multisense::image::Config &cfg, const T& dyn)
+{
+    crl::multisense::CameraProfile profile = crl::multisense::User_Control;
+    profile |= (dyn.detail_disparity_profile ? crl::multisense::Detail_Disparity : profile);
+    profile |= (dyn.high_contrast_profile ? crl::multisense::High_Contrast : profile);
+    profile |= (dyn.show_roi_profile ? crl::multisense::Show_ROIs : profile);
     profile |= (dyn.ground_surface_profile ? crl::multisense::Ground_Surface : profile);
     profile |= (dyn.full_res_aux_profile ? crl::multisense::Full_Res_Aux_Cam : profile);
 
@@ -749,10 +760,6 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
 
     // Update camera class locally to modify pointcloud transform in rviz
     extrinsics_callback_(calibration);
-
-    // TODO(drobinson): Handle multiple calls to asyncronous flash write
-    // FORNOW: Delay to ensure that other callbacks can write to flash
-    std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
 template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
@@ -818,10 +825,6 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
                         Channel::statusString(status));
         return;
     }
-
-    // TODO(drobinson): Handle multiple calls to asyncronous flash write
-    // FORNOW: Delay to ensure that other callbacks can write to flash
-    std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
 #define GET_CONFIG()                                                    \
@@ -842,7 +845,6 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
-        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define SL_BM_IMU()  do {                                       \
@@ -855,7 +857,6 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
-        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define MONO_BM_IMU()  do {                                     \
@@ -865,7 +866,6 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureLeds(dyn);                                     \
         configureImu(dyn);                                      \
         configureExtrinsics(dyn);                               \
-        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define SL_SGM_IMU()  do {                                      \
@@ -880,7 +880,6 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
-        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define SL_SGM()  do {                                          \
@@ -892,7 +891,6 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
-        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define SL_SGM_IMU_CMV4000()  do {                              \
@@ -908,13 +906,12 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
-        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define S27_SGM()  do {                                         \
         GET_CONFIG();                                           \
         configureSgm(cfg, dyn);                                 \
-        configureStereoProfile(cfg, dyn);                       \
+        configureStereoProfileWithGroundSurface(cfg, dyn);      \
         configureAutoWhiteBalance(cfg, dyn);                    \
         configureAuxCamera(cfg, dyn);                           \
         configureCamera(cfg, dyn);                              \
@@ -922,7 +919,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configurePtp(dyn);                                      \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
-        configureGroundSurfaceParams(dyn);                            \
+        configureGroundSurfaceParams(dyn);                      \
     } while(0)
 
 #define KS21_SGM()  do {                                        \
@@ -935,7 +932,6 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configurePtp(dyn);                                      \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
-        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -703,17 +703,6 @@ template<class T> void Reconfigure::configureStereoProfile(crl::multisense::imag
     profile |= (dyn.detail_disparity_profile ? crl::multisense::Detail_Disparity : profile);
     profile |= (dyn.high_contrast_profile ? crl::multisense::High_Contrast : profile);
     profile |= (dyn.show_roi_profile ? crl::multisense::Show_ROIs : profile);
-    profile |= (dyn.full_res_aux_profile ? crl::multisense::Full_Res_Aux_Cam : profile);
-
-    cfg.setCameraProfile(profile);
-}
-
-template<class T> void Reconfigure::configureStereoProfileWithGroundSurface(crl::multisense::image::Config &cfg, const T& dyn)
-{
-    crl::multisense::CameraProfile profile = crl::multisense::User_Control;
-    profile |= (dyn.detail_disparity_profile ? crl::multisense::Detail_Disparity : profile);
-    profile |= (dyn.high_contrast_profile ? crl::multisense::High_Contrast : profile);
-    profile |= (dyn.show_roi_profile ? crl::multisense::Show_ROIs : profile);
     profile |= (dyn.ground_surface_profile ? crl::multisense::Ground_Surface : profile);
     profile |= (dyn.full_res_aux_profile ? crl::multisense::Full_Res_Aux_Cam : profile);
 
@@ -815,6 +804,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                      \
     } while(0)
 
 #define SL_BM_IMU()  do {                                       \
@@ -827,6 +817,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                      \
     } while(0)
 
 #define MONO_BM_IMU()  do {                                     \
@@ -836,6 +827,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureLeds(dyn);                                     \
         configureImu(dyn);                                      \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                      \
     } while(0)
 
 #define SL_SGM_IMU()  do {                                      \
@@ -850,6 +842,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                      \
     } while(0)
 
 #define SL_SGM()  do {                                          \
@@ -861,6 +854,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                      \
     } while(0)
 
 #define SL_SGM_IMU_CMV4000()  do {                              \
@@ -876,12 +870,13 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                      \
     } while(0)
 
 #define S27_SGM()  do {                                         \
         GET_CONFIG();                                           \
         configureSgm(cfg, dyn);                                 \
-        configureStereoProfileWithGroundSurface(cfg, dyn);      \
+        configureStereoProfile(cfg, dyn);                       \
         configureAutoWhiteBalance(cfg, dyn);                    \
         configureAuxCamera(cfg, dyn);                           \
         configureCamera(cfg, dyn);                              \
@@ -902,6 +897,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         configurePtp(dyn);                                      \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                      \
     } while(0)
 
 

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -42,7 +42,7 @@ Reconfigure::Reconfigure(Channel* driver,
                          std::function<void (BorderClip, double)> borderClipChangeCallback,
                          std::function<void (double)> maxPointCloudRangeCallback,
                          std::function<void (crl::multisense::system::ExternalCalibration)> extrinsicsCallback,
-                         std::function<void (double, double, double, double, double)> groundSurfaceSplineResolutionCallback):
+                         std::function<void (ground_surface_utilities::SplineDrawingParams)> groundSurfaceSplineResolutionCallback):
     external_calibration_retrieved_from_flash_(false),
     ground_surface_params_retrieved_from_flash_(false),
     driver_(driver),
@@ -755,13 +755,16 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
 
 template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
 {
-    // Update spline drawing resolution (this is handled by the ros driver)
+    //
+    // Update spline drawing parameters locally
     ground_surface_spline_resolution_callback_(
-        dyn.ground_surface_spline_draw_resolution,
+        ground_surface_utilities::SplineDrawingParams{
         dyn.ground_surface_pointcloud_global_max_z_m,
         dyn.ground_surface_pointcloud_global_min_z_m,
         dyn.ground_surface_pointcloud_global_max_x_m,
-        dyn.ground_surface_pointcloud_global_min_x_m);
+        dyn.ground_surface_pointcloud_global_min_x_m,
+        dyn.ground_surface_spline_draw_resolution}
+    );
 
     //
     // Update calibration on camera via libmultisense

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -43,8 +43,6 @@ Reconfigure::Reconfigure(Channel* driver,
                          std::function<void (double)> maxPointCloudRangeCallback,
                          std::function<void (crl::multisense::system::ExternalCalibration)> extrinsicsCallback,
                          std::function<void (ground_surface_utilities::SplineDrawingParams)> groundSurfaceSplineResolutionCallback):
-    external_calibration_retrieved_from_flash_(false),
-    ground_surface_params_retrieved_from_flash_(false),
     driver_(driver),
     resolution_change_callback_(resolutionChangeCallback),
     device_nh_(""),
@@ -737,11 +735,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
     calibration.pitch = dyn.origin_from_camera_rotation_y_deg * deg_to_rad;
     calibration.yaw = dyn.origin_from_camera_rotation_z_deg * deg_to_rad;
 
-    // If they have changed, update the internal copy of the calibration
-    calibration_ = calibration;
-
     // Update extrinsics on camera
-    const std::lock_guard<std::mutex> lock(flash_write_);
     Status status = driver_->setExternalCalibration(calibration);
     if (Status_Ok != status) {
             ROS_ERROR("Reconfigure: failed to set external calibration: %s",
@@ -794,11 +788,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
     params.ground_surface_max_fitting_iterations = dyn.ground_surface_max_fitting_iterations;
     params.ground_surface_adjacent_cell_search_size_m = dyn.ground_surface_adjacent_cell_search_size_m;
 
-    // If they have changed, update the internal copy of the parameters
-    params_ = params;
-
     // Update ground surface params on camera
-    const std::lock_guard<std::mutex> lock(flash_write_);
     Status status = driver_->setGroundSurfaceParams(params);
     if (Status_Ok != status) {
             ROS_ERROR("Reconfigure: failed to set ground surface params: %s",

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -738,6 +738,44 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
     extrinsics_callback_(calibration);
 }
 
+template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
+{
+    // TODO(drobinson): Initialize to values stored in flash rather than overwriting to default
+    //                  multisense.cfg values
+
+    //
+    // Update calibration on camera via libmultisense
+    crl::multisense::system::GroundSurfaceParams params;
+
+    std::cout << dyn.ground_surface_base_model << std::endl;
+
+    params.ground_surface_number_of_levels_x = dyn.ground_surface_number_of_levels_x;
+    params.ground_surface_number_of_levels_z = dyn.ground_surface_number_of_levels_z;
+    params.ground_surface_base_model = dyn.ground_surface_base_model;
+    params.ground_surface_pointcloud_grid_size = dyn.ground_surface_pointcloud_grid_size;
+    params.ground_surface_min_points_per_grid = dyn.ground_surface_min_points_per_grid;
+    params.ground_surface_pointcloud_decimation = dyn.ground_surface_pointcloud_decimation;
+    params.ground_surface_pointcloud_max_range_m = dyn.ground_surface_pointcloud_max_range_m;
+    params.ground_surface_pointcloud_min_range_m = dyn.ground_surface_pointcloud_min_range_m;
+    params.ground_surface_pointcloud_max_width_m = dyn.ground_surface_pointcloud_max_width_m;
+    params.ground_surface_pointcloud_min_width_m = dyn.ground_surface_pointcloud_min_width_m;
+    params.ground_surface_pointcloud_max_height_m = dyn.ground_surface_pointcloud_max_height_m;
+    params.ground_surface_pointcloud_min_height_m = dyn.ground_surface_pointcloud_min_height_m;
+    params.ground_surface_obstacle_height_thresh_m = dyn.ground_surface_obstacle_height_thresh_m;
+    params.ground_surface_obstacle_percentage_thresh = dyn.ground_surface_obstacle_percentage_thresh;
+    params.ground_surface_spline_draw_resolution = dyn.ground_surface_spline_draw_resolution;
+    params.ground_surface_max_fitting_iterations = dyn.ground_surface_max_fitting_iterations;
+    params.ground_surface_adjacent_cell_search_size_m = dyn.ground_surface_adjacent_cell_search_size_m;
+
+    // Update ground surface params on camera
+    Status status = driver_->setGroundSurfaceParams(params);
+    if (Status_Ok != status) {
+            ROS_ERROR("Reconfigure: failed to set ground surface params: %s",
+                        Channel::statusString(status));
+        return;
+    }
+}
+
 #define GET_CONFIG()                                                    \
     image::Config cfg;                                                  \
     Status status = driver_->getImageConfig(cfg);                       \
@@ -756,6 +794,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define SL_BM_IMU()  do {                                       \
@@ -768,6 +807,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define MONO_BM_IMU()  do {                                     \
@@ -777,6 +817,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureLeds(dyn);                                     \
         configureImu(dyn);                                      \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define SL_SGM_IMU()  do {                                      \
@@ -791,6 +832,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define SL_SGM()  do {                                          \
@@ -802,6 +844,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define SL_SGM_IMU_CMV4000()  do {                              \
@@ -817,6 +860,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configureBorderClip(dyn);                               \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define S27_SGM()  do {                                         \
@@ -830,6 +874,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configurePtp(dyn);                                      \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 #define KS21_SGM()  do {                                        \
@@ -842,6 +887,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         configurePtp(dyn);                                      \
         configurePointCloudRange(dyn);                          \
         configureExtrinsics(dyn);                               \
+        configureGroundSurfaceParams(dyn);                            \
     } while(0)
 
 

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -42,7 +42,7 @@ Reconfigure::Reconfigure(Channel* driver,
                          std::function<void (BorderClip, double)> borderClipChangeCallback,
                          std::function<void (double)> maxPointCloudRangeCallback,
                          std::function<void (crl::multisense::system::ExternalCalibration)> extrinsicsCallback,
-                         std::function<void (ground_surface_utilities::SplineDrawingParams)> groundSurfaceSplineResolutionCallback):
+                         std::function<void (ground_surface_utilities::SplineDrawParameters)> groundSurfaceSplineDrawParametersCallback):
     driver_(driver),
     resolution_change_callback_(resolutionChangeCallback),
     device_nh_(""),
@@ -58,7 +58,7 @@ Reconfigure::Reconfigure(Channel* driver,
     border_clip_change_callback_(borderClipChangeCallback),
     max_point_cloud_range_callback_(maxPointCloudRangeCallback),
     extrinsics_callback_(extrinsicsCallback),
-    ground_surface_spline_resolution_callback_(groundSurfaceSplineResolutionCallback)
+    spline_draw_parameters_callback_(groundSurfaceSplineDrawParametersCallback)
 {
     system::DeviceInfo  deviceInfo;
     system::VersionInfo versionInfo;
@@ -740,8 +740,8 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
 {
     //
     // Update spline drawing parameters locally
-    ground_surface_spline_resolution_callback_(
-        ground_surface_utilities::SplineDrawingParams{
+    spline_draw_parameters_callback_(
+        ground_surface_utilities::SplineDrawParameters{
         dyn.ground_surface_pointcloud_global_max_z_m,
         dyn.ground_surface_pointcloud_global_min_z_m,
         dyn.ground_surface_pointcloud_global_max_x_m,

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -788,17 +788,6 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
 template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
 {
     //
-    // Update spline drawing parameters locally
-    spline_draw_parameters_callback_(
-        ground_surface_utilities::SplineDrawParameters{
-        dyn.ground_surface_pointcloud_global_max_z_m,
-        dyn.ground_surface_pointcloud_global_min_z_m,
-        dyn.ground_surface_pointcloud_global_max_x_m,
-        dyn.ground_surface_pointcloud_global_min_x_m,
-        dyn.ground_surface_spline_draw_resolution}
-    );
-
-    //
     // Update calibration on camera via libmultisense
     crl::multisense::system::GroundSurfaceParams params;
 
@@ -833,6 +822,17 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
                         Channel::statusString(status));
         return;
     }
+
+    //
+    // Update spline drawing parameters locally
+    spline_draw_parameters_callback_(
+        ground_surface_utilities::SplineDrawParameters{
+        dyn.ground_surface_pointcloud_global_max_z_m,
+        dyn.ground_surface_pointcloud_global_min_z_m,
+        dyn.ground_surface_pointcloud_global_max_x_m,
+        dyn.ground_surface_pointcloud_global_min_x_m,
+        dyn.ground_surface_spline_draw_resolution}
+    );
 }
 
 #define GET_CONFIG()                                                    \

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -735,7 +735,7 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
         calibration_.yaw == calibration.yaw)
         return;
 
-    // If they have changed, update the intrernal copy of the calibration
+    // If they have changed, update the internal copy of the calibration
     calibration_ = calibration;
 
     // Update extrinsics on camera
@@ -807,7 +807,7 @@ template<class T> void Reconfigure::configureGroundSurfaceParams(const T& dyn)
         params_.ground_surface_adjacent_cell_search_size_m == params.ground_surface_adjacent_cell_search_size_m)
         return;
 
-    // If they have changed, update the intrernal copy of the parameters
+    // If they have changed, update the internal copy of the parameters
     params_ = params;
 
     // Update ground surface params on camera

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -87,12 +87,10 @@ Reconfigure::Reconfigure(Channel* driver,
         return;
     }
 
-    bool ground_surface_supported = false;
-    for (auto &mode : deviceModes)
-    {
-        ground_surface_supported |= (mode.supportedDataSources & Source_Ground_Surface_Spline_Data) &&
-                                    (mode.supportedDataSources & Source_Ground_Surface_Class_Image);
-    }
+    const bool ground_surface_supported =
+        std::any_of(deviceModes.begin(), deviceModes.end(), [](const auto &mode) {
+            return (mode.supportedDataSources & Source_Ground_Surface_Spline_Data) &&
+                   (mode.supportedDataSources & Source_Ground_Surface_Class_Image); });
 
     if (deviceInfo.lightingType != 0 || system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21 == deviceInfo.hardwareRevision)
     {

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argvPP)
                                              std::bind(&multisense_ros::Camera::extrinsicsChanged, &camera,
                                                        std::placeholders::_1),
                                              std::bind(&multisense_ros::Camera::groundSurfaceSplineResolutionChanged, &camera,
-                                                       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
+                                                       std::placeholders::_1));
             ros::spin();
         }
 

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -95,6 +95,8 @@ int main(int argc, char** argvPP)
                                              std::bind(&multisense_ros::Camera::maxPointCloudRangeChanged, &camera,
                                                        std::placeholders::_1),
                                              std::bind(&multisense_ros::Camera::extrinsicsChanged, &camera,
+                                                       std::placeholders::_1),
+                                             std::bind(&multisense_ros::Camera::groundSurfaceSplineResolutionChanged, &camera,
                                                        std::placeholders::_1));
             ros::spin();
         }

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argvPP)
                                              std::bind(&multisense_ros::Camera::extrinsicsChanged, &camera,
                                                        std::placeholders::_1),
                                              std::bind(&multisense_ros::Camera::groundSurfaceSplineResolutionChanged, &camera,
-                                                       std::placeholders::_1));
+                                                       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
             ros::spin();
         }
 

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argvPP)
                                                        std::placeholders::_1),
                                              std::bind(&multisense_ros::Camera::extrinsicsChanged, &camera,
                                                        std::placeholders::_1),
-                                             std::bind(&multisense_ros::Camera::groundSurfaceSplineResolutionChanged, &camera,
+                                             std::bind(&multisense_ros::Camera::groundSurfaceSplineDrawParametersChanged, &camera,
                                                        std::placeholders::_1));
             ros::spin();
         }


### PR DESCRIPTION
Expose ground surface parameters to the user in the dynamic reconfigure GUI, like so:

![image](https://user-images.githubusercontent.com/18414839/165158680-197ff262-4ea9-4177-ac46-1310f86ad527.png)
