### PR TITLE
Minor bugfix for S27 support

### DIFF
--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -2137,8 +2137,19 @@ void Camera::publishAllCameraInfo()
 
         if (system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21 != device_info_.hardwareRevision) {
 
-            left_rgb_cam_info_pub_.publish(left_camera_info);
-            left_rgb_rect_cam_info_pub_.publish(left_rectified_camera_info);
+            if (has_aux_camera_) {
+
+                aux_mono_cam_info_pub_.publish(left_camera_info);
+                aux_rgb_cam_info_pub_.publish(left_camera_info);
+                aux_rect_cam_info_pub_.publish(left_rectified_camera_info);
+                aux_rgb_rect_cam_info_pub_.publish(left_rectified_camera_info);
+
+            } else {
+
+                left_rgb_cam_info_pub_.publish(left_camera_info);
+                left_rgb_rect_cam_info_pub_.publish(left_rectified_camera_info);
+
+            }
         }
 
         if (version_info_.sensorFirmwareVersion >= 0x0300) {

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -369,7 +369,7 @@ template<class T> void Reconfigure::configureAuxCamera(image::Config& cfg, const
                                                   return c.exposureSource() == Source_Luma_Aux;
                                               });
 
-        if (auxExposureConfig != std::end(secondaryExposures)) {
+        if (auxExposureConfig == std::end(secondaryExposures)) {
             image::ExposureConfig auxConfig;
             auxConfig.setExposureSource(Source_Luma_Aux);
             secondaryExposures.push_back(auxConfig);


### PR DESCRIPTION
Populating the aux publishers when we have an aux camera.
Minor bugfix in the secondary exposures logic in dynamic reconfigure.