### PR TITLE
Only set the extrinsics calibration if it changed

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -285,7 +285,6 @@ for cfg in sensorConfigList:
 
     gen.add("max_point_cloud_range", double_t, 0, "max point cloud range", 15.0, 0.0, 100.0)
 
-    gen.add("write_extrinsics_to_flash", bool_t, 0, "Write camera extrinsics to flash", False)
     gen.add("origin_from_camera_position_x_m", double_t, 0, "Origin from camera extrinsics transform x value (m)", 0.0, -100.0, 100.0)
     gen.add("origin_from_camera_position_y_m", double_t, 0, "Origin from camera extrinsics transform y value (m)", 0.0, -100.0, 100.0)
     gen.add("origin_from_camera_position_z_m", double_t, 0, "Origin from camera extrinsics transform z value (m)", 0.0, -100.0, 100.0)

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -285,6 +285,7 @@ for cfg in sensorConfigList:
 
     gen.add("max_point_cloud_range", double_t, 0, "max point cloud range", 15.0, 0.0, 100.0)
 
+    gen.add("write_extrinsics_to_flash", bool_t, 0, "Write camera extrinsics to flash", False)
     gen.add("origin_from_camera_position_x_m", double_t, 0, "Origin from camera extrinsics transform x value (m)", 0.0, -100.0, 100.0)
     gen.add("origin_from_camera_position_y_m", double_t, 0, "Origin from camera extrinsics transform y value (m)", 0.0, -100.0, 100.0)
     gen.add("origin_from_camera_position_z_m", double_t, 0, "Origin from camera extrinsics transform z value (m)", 0.0, -100.0, 100.0)

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -175,7 +175,7 @@ private:
     //
     // Extrinsics callback to modify pointcloud
 
-    bool set_extrinsics_ = false;
+    crl::multisense::system::ExternalCalibration calibration_;
     std::function<void (crl::multisense::system::ExternalCalibration)> extrinsics_callback_;
 };
 

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -175,6 +175,7 @@ private:
     //
     // Extrinsics callback to modify pointcloud
 
+    bool set_extrinsics_ = false;
     std::function<void (crl::multisense::system::ExternalCalibration)> extrinsics_callback_;
 };
 

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -57,7 +57,6 @@ Reconfigure::Reconfigure(Channel* driver,
     border_clip_value_(0.0),
     border_clip_change_callback_(borderClipChangeCallback),
     max_point_cloud_range_callback_(maxPointCloudRangeCallback),
-    set_extrinsics_(false),
     extrinsics_callback_(extrinsicsCallback)
 {
     system::DeviceInfo  deviceInfo;
@@ -78,6 +77,7 @@ Reconfigure::Reconfigure(Channel* driver,
                   Channel::statusString(status));
         return;
     }
+
 
     if (deviceInfo.lightingType != 0 || system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21 == deviceInfo.hardwareRevision)
     {
@@ -260,6 +260,9 @@ Reconfigure::Reconfigure(Channel* driver,
             return;
         }
     }
+
+    calibration_ = crl::multisense::system::ExternalCalibration{};
+    extrinsics_callback_(calibration_);
 }
 
 Reconfigure::~Reconfigure()
@@ -713,52 +716,29 @@ template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
 {
     // TODO(drobinson): Initialize to values stored in flash rather than overwriting camera extrinsics to
     //                  default multisense.cfg values
-    crl::multisense::system::ExternalCalibration calibration;
-    Status status = driver_->getExternalCalibration(calibration);
-    if (Status_Ok != status) {
-            ROS_ERROR("Reconfigure: failed to get external calibration: %s",
-                        Channel::statusString(status));
-        return;
-    }
-
     constexpr float deg_to_rad = M_PI / 180.0f;
-    if (std::abs(dyn.origin_from_camera_position_x_m - calibration.x) < 1e-3 &&
-        std::abs(dyn.origin_from_camera_position_y_m - calibration.y) < 1e-3 &&
-        std::abs(dyn.origin_from_camera_position_z_m - calibration.z) < 1e-3 &&
-        std::abs(dyn.origin_from_camera_rotation_x_deg * deg_to_rad - calibration.roll) < 1e-3 &&
-        std::abs(dyn.origin_from_camera_rotation_y_deg * deg_to_rad - calibration.pitch) < 1e-3 &&
-        std::abs(dyn.origin_from_camera_rotation_z_deg * deg_to_rad - calibration.yaw) < 1e-3) {
-
-        if (!set_extrinsics_) {
-            extrinsics_callback_(calibration);
-            set_extrinsics_ = true;
-        }
+    if (std::abs(dyn.origin_from_camera_position_x_m - calibration_.x) < 1e-3 &&
+        std::abs(dyn.origin_from_camera_position_y_m - calibration_.y) < 1e-3 &&
+        std::abs(dyn.origin_from_camera_position_z_m - calibration_.z) < 1e-3 &&
+        std::abs(dyn.origin_from_camera_rotation_x_deg * deg_to_rad - calibration_.roll) < 1e-3 &&
+        std::abs(dyn.origin_from_camera_rotation_y_deg * deg_to_rad - calibration_.pitch) < 1e-3 &&
+        std::abs(dyn.origin_from_camera_rotation_z_deg * deg_to_rad - calibration_.yaw) < 1e-3) {
         return;
     }
 
     //
     // Update calibration on camera via libmultisense
 
-    calibration.x = dyn.origin_from_camera_position_x_m;
-    calibration.y = dyn.origin_from_camera_position_y_m;
-    calibration.z = dyn.origin_from_camera_position_z_m;
+    calibration_.x = dyn.origin_from_camera_position_x_m;
+    calibration_.y = dyn.origin_from_camera_position_y_m;
+    calibration_.z = dyn.origin_from_camera_position_z_m;
 
-    calibration.roll = dyn.origin_from_camera_rotation_x_deg * deg_to_rad;
-    calibration.pitch = dyn.origin_from_camera_rotation_y_deg * deg_to_rad;
-    calibration.yaw = dyn.origin_from_camera_rotation_z_deg * deg_to_rad;
-
-    // Update extrinsics on camera
-    if (dyn.write_extrinsics_to_flash) {
-        status = driver_->setExternalCalibration(calibration);
-        if (Status_Ok != status) {
-                ROS_ERROR("Reconfigure: failed to set external calibration: %s",
-                            Channel::statusString(status));
-            return;
-        }
-    }
+    calibration_.roll = dyn.origin_from_camera_rotation_x_deg * deg_to_rad;
+    calibration_.pitch = dyn.origin_from_camera_rotation_y_deg * deg_to_rad;
+    calibration_.yaw = dyn.origin_from_camera_rotation_z_deg * deg_to_rad;
 
     // Update camera class locally to modify pointcloud transform in rviz
-    extrinsics_callback_(calibration);
+    extrinsics_callback_(calibration_);
 }
 
 #define GET_CONFIG()                                                    \

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -714,8 +714,6 @@ template<class T> void Reconfigure::configureStereoProfile(crl::multisense::imag
 
 template<class T> void Reconfigure::configureExtrinsics(const T& dyn)
 {
-    // TODO(drobinson): Initialize to values stored in flash rather than overwriting camera extrinsics to
-    //                  default multisense.cfg values
     constexpr float deg_to_rad = M_PI / 180.0f;
     if (std::abs(dyn.origin_from_camera_position_x_m - calibration_.x) < 1e-3 &&
         std::abs(dyn.origin_from_camera_position_y_m - calibration_.y) < 1e-3 &&


### PR DESCRIPTION
Make sure we don't set the extrinsic calibration on each dynamic reconfigure change. This data is written to flash, and we don't want to abuse that. 