### PR TITLE
Properly handle the full translation between left/aux rectified images

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -136,7 +136,7 @@ for feature_name, feature in SupportedFeatures.__members__.items():
                                 gen.const("1920x1200_256_disparities", str_t, "1920x1200x256", "1920x1200x256") ],
                                 "Available resolution settings")
             gen.add("resolution", str_t, 0, "sensor resolution", "960x600x256", edit_method=res_enum)
-            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 64.0)
+            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
             roi_width = 1920
             roi_height = 1200
             auto_exposure_threshold = 0.95

--- a/multisense_ros/include/multisense_ros/camera_utilities.h
+++ b/multisense_ros/include/multisense_ros/camera_utilities.h
@@ -180,13 +180,29 @@ public:
     ///
     /// @brief Reproject disparity values into 3D
     ///
-    Eigen::Vector3f reproject(size_t u, size_t v, double d);
+    Eigen::Vector3f reproject(size_t u, size_t v, double d) const;
+
+    ///
+    /// @brief Reproject disparity values into 3D
+    ///
+    Eigen::Vector3f reproject(size_t u,
+                              size_t v,
+                              double d,
+                              const sensor_msgs::CameraInfo &left_camera_info,
+                              const sensor_msgs::CameraInfo &right_camera_info) const;
 
     ///
     /// @brief Project points corresponding to disparity measurements in the left rectified image frame into the
     ///        aux rectified image plane
     ///
-    Eigen::Vector2f rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point);
+    Eigen::Vector2f rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point) const;
+
+    ///
+    /// @brief Project points corresponding to disparity measurements in the left rectified image frame into the
+    ///        aux rectified image plane
+    ///
+    Eigen::Vector2f rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point,
+                                        const sensor_msgs::CameraInfo &aux_camera_info) const;
 
     ///
     /// @brief Get the current main stereo pair operating resolution. This resolution applies for both the mono

--- a/multisense_ros/include/multisense_ros/camera_utilities.h
+++ b/multisense_ros/include/multisense_ros/camera_utilities.h
@@ -166,14 +166,27 @@ public:
     Eigen::Matrix4d Q() const;
 
     ///
-    /// @brief Translation which transforms points from the right camera frame into the left camera frame
+    /// @brief Translation which transforms points from the rectified left camera frame into the recified right camera
+    /// frame
     ///
     double T() const;
 
     ///
-    /// @brief Translation which transforms points from the aux camera frame into the left camera frame
+    /// @brief Translation which transforms points from the rectified left camera frame into the rectified aux
+    /// camera frame
     ///
-    double aux_T() const;
+    Eigen::Vector3d aux_T() const;
+
+    ///
+    /// @brief Reproject disparity values into 3D
+    ///
+    Eigen::Vector3f reproject(size_t u, size_t v, double d);
+
+    ///
+    /// @brief Project points corresponding to disparity measurements in the left rectified image frame into the
+    ///        aux rectified image plane
+    ///
+    Eigen::Vector2f rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point);
 
     ///
     /// @brief Get the current main stereo pair operating resolution. This resolution applies for both the mono

--- a/multisense_ros/src/camera_utilities.cpp
+++ b/multisense_ros/src/camera_utilities.cpp
@@ -393,8 +393,8 @@ Eigen::Vector2f StereoCalibrationManger::rectifiedAuxProject(const Eigen::Vector
     //
     // Project the left_rectified_point into the aux image using the auxP matrix
     //
-    const double uB = (fx * left_rectified_point(0) + cx + fxtx);
-    const double vB = (fy * left_rectified_point(1) + cy + fyty);
+    const double uB = (fx * left_rectified_point(0) + (cx * left_rectified_point(2)) + fxtx);
+    const double vB = (fy * left_rectified_point(1) + (cy * left_rectified_point(2)) + fyty);
     const double invB = 1.0 / (left_rectified_point(2) + tz);
 
     return Eigen::Vector2f{static_cast<float>(uB * invB), static_cast<float>(vB * invB)};

--- a/multisense_ros/src/camera_utilities.cpp
+++ b/multisense_ros/src/camera_utilities.cpp
@@ -352,7 +352,18 @@ Eigen::Vector3d StereoCalibrationManger::aux_T() const
                            aux_camera_info_.P[11]};
 }
 
-Eigen::Vector3f StereoCalibrationManger::reproject(size_t u, size_t v, double d)
+Eigen::Vector3f StereoCalibrationManger::reproject(size_t u, size_t v, double d) const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    return reproject(u, v, d, left_camera_info_, right_camera_info_);
+}
+
+Eigen::Vector3f StereoCalibrationManger::reproject(size_t u,
+                                                   size_t v,
+                                                   double d,
+                                                   const sensor_msgs::CameraInfo &left_camera_info,
+                                                   const sensor_msgs::CameraInfo &right_camera_info) const
 {
     if (d == 0.0)
     {
@@ -361,14 +372,13 @@ Eigen::Vector3f StereoCalibrationManger::reproject(size_t u, size_t v, double d)
                                std::numeric_limits<float>::max()};
     }
 
-    std::lock_guard<std::mutex> lock(mutex_);
 
-    const double &fx = left_camera_info_.P[0];
-    const double &fy = left_camera_info_.P[5];
-    const double &cx = left_camera_info_.P[2];
-    const double &cy = left_camera_info_.P[6];
-    const double &cx_right = right_camera_info_.P[2];
-    const double tx = right_camera_info_.P[3] / right_camera_info_.P[0];
+    const double &fx = left_camera_info.P[0];
+    const double &fy = left_camera_info.P[5];
+    const double &cx = left_camera_info.P[2];
+    const double &cy = left_camera_info.P[6];
+    const double &cx_right = right_camera_info.P[2];
+    const double tx = right_camera_info.P[3] / right_camera_info.P[0];
 
     const double xB = ((fy * tx) * u) + (-fy * cx * tx);
     const double yB = ((fx * tx) * v) + (-fx * cy * tx);
@@ -378,17 +388,23 @@ Eigen::Vector3f StereoCalibrationManger::reproject(size_t u, size_t v, double d)
     return Eigen::Vector3f{static_cast<float>(xB * invB), static_cast<float>(yB * invB), static_cast<float>(zB * invB)};
 }
 
-Eigen::Vector2f StereoCalibrationManger::rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point)
+Eigen::Vector2f StereoCalibrationManger::rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point) const
 {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    const double &fx = aux_camera_info_.P[0];
-    const double &fy = aux_camera_info_.P[5];
-    const double &cx = aux_camera_info_.P[2];
-    const double &cy = aux_camera_info_.P[6];
-    const double &fxtx = aux_camera_info_.P[3];
-    const double &fyty = aux_camera_info_.P[7];
-    const double &tz = aux_camera_info_.P[11];
+    return rectifiedAuxProject(left_rectified_point, aux_camera_info_);
+}
+
+Eigen::Vector2f StereoCalibrationManger::rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point,
+                                                             const sensor_msgs::CameraInfo &aux_camera_info) const
+{
+    const double &fx = aux_camera_info.P[0];
+    const double &fy = aux_camera_info.P[5];
+    const double &cx = aux_camera_info.P[2];
+    const double &cy = aux_camera_info.P[6];
+    const double &fxtx = aux_camera_info.P[3];
+    const double &fyty = aux_camera_info.P[7];
+    const double &tz = aux_camera_info.P[11];
 
     //
     // Project the left_rectified_point into the aux image using the auxP matrix

--- a/multisense_ros/src/camera_utilities.cpp
+++ b/multisense_ros/src/camera_utilities.cpp
@@ -334,20 +334,70 @@ double StereoCalibrationManger::T() const
     return right_camera_info_.P[3] / right_camera_info_.P[0];
 }
 
-double StereoCalibrationManger::aux_T() const
+Eigen::Vector3d StereoCalibrationManger::aux_T() const
 {
     std::lock_guard<std::mutex> lock(mutex_);
 
     //
     // The aux camera projection matrix is of the form:
     //
-    // [fx,  0, cx, t * fx]
-    // [ 0, fy, cy, 0     ]
-    // [ 0,  0,  1, 0     ]
+    // [fx,  0, cx, tx * fx]
+    // [ 0, fy, cy, ty * fy]
+    // [ 0,  0,  1, tz     ]
     //
     // divide the t * fx term by fx to get t
 
-    return aux_camera_info_.P[3] / aux_camera_info_.P[0];
+    return Eigen::Vector3d{aux_camera_info_.P[3] / aux_camera_info_.P[0],
+                           aux_camera_info_.P[7] / aux_camera_info_.P[5],
+                           aux_camera_info_.P[11]};
+}
+
+Eigen::Vector3f StereoCalibrationManger::reproject(size_t u, size_t v, double d)
+{
+    if (d == 0.0)
+    {
+        return Eigen::Vector3f{std::numeric_limits<float>::max(),
+                               std::numeric_limits<float>::max(),
+                               std::numeric_limits<float>::max()};
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    const double &fx = left_camera_info_.P[0];
+    const double &fy = left_camera_info_.P[5];
+    const double &cx = left_camera_info_.P[2];
+    const double &cy = left_camera_info_.P[6];
+    const double &cx_right = right_camera_info_.P[2];
+    const double tx = right_camera_info_.P[3] / right_camera_info_.P[0];
+
+    const double xB = ((fy * tx) * u) + (-fy * cx * tx);
+    const double yB = ((fx * tx) * v) + (-fx * cy * tx);
+    const double zB = (fx * fy * tx);
+    const double invB = 1. / (-fy * d) + (fy * (cx - cx_right));
+
+    return Eigen::Vector3f{static_cast<float>(xB * invB), static_cast<float>(yB * invB), static_cast<float>(zB * invB)};
+}
+
+Eigen::Vector2f StereoCalibrationManger::rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    const double &fx = aux_camera_info_.P[0];
+    const double &fy = aux_camera_info_.P[5];
+    const double &cx = aux_camera_info_.P[2];
+    const double &cy = aux_camera_info_.P[6];
+    const double &fxtx = aux_camera_info_.P[3];
+    const double &fyty = aux_camera_info_.P[7];
+    const double &tz = aux_camera_info_.P[11];
+
+    //
+    // Project the left_rectified_point into the aux image using the auxP matrix
+    //
+    const double uB = (fx * left_rectified_point(0) + cx + fxtx);
+    const double vB = (fy * left_rectified_point(1) + cy + fyty);
+    const double invB = 1.0 / (left_rectified_point(2) + tz);
+
+    return Eigen::Vector2f{static_cast<float>(uB * invB), static_cast<float>(vB * invB)};
 }
 
 OperatingResolutionT StereoCalibrationManger::operatingStereoResolution() const
@@ -374,7 +424,8 @@ OperatingResolutionT StereoCalibrationManger::operatingAuxResolution() const
 
 bool StereoCalibrationManger::validAux() const
 {
-    return std::isfinite(aux_T());
+    const Eigen::Vector3d auxT = aux_T();
+    return std::isfinite(auxT(0)) && std::isfinite(auxT(1)) && std::isfinite(auxT(2)) ;
 }
 
 sensor_msgs::CameraInfo StereoCalibrationManger::leftCameraInfo(const std::string& frame_id,


### PR DESCRIPTION
Account for the full 3DOF translation between the left/aux rectified image frames when publishing aux transforms and colorizing pointclouds with aux images