### PR TITLE
ptp: Add support for PTP timestamps with UTC/TAI configuration params and diagnostics.

### DIFF
--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -78,7 +78,7 @@ public:
     void groundSurfaceCallback(const crl::multisense::image::Header& header);
     void groundSurfaceSplineCallback(const crl::multisense::ground_surface::Header& header);
 
-    void borderClipChanged(const BorderClip &borderClipType, double borderClipValue);
+    void borderClipChanged(const BorderClip& borderClipType, double borderClipValue);
 
     void maxPointCloudRangeChanged(double range);
 
@@ -348,15 +348,17 @@ private:
     //
     // Diagnostics
     diagnostic_updater::Updater diagnostic_updater_;
-    void deviceInfoDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
-    void deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    void deviceInfoDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
+    void deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
     void ptpStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
 
-    void diagnosticTimerCallback(const ros::TimerEvent &);
+    void diagnosticTimerCallback(const ros::TimerEvent&);
     ros::Timer diagnostic_trigger_;
 
     //
-    // Timesync settings
+    // Timestamping and timesync settings
+    ros::Time convertImageTimestamp(uint32_t time_secs, uint32_t time_microsecs);
+
     bool ptp_time_sync_ = false;
     bool network_time_sync_ = false;
     std::atomic_bool ptp_status_;

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -78,7 +78,7 @@ public:
     void groundSurfaceCallback(const crl::multisense::image::Header& header);
     void groundSurfaceSplineCallback(const crl::multisense::ground_surface::Header& header);
 
-    void borderClipChanged(const BorderClip& borderClipType, double borderClipValue);
+    void borderClipChanged(const BorderClip &borderClipType, double borderClipValue);
 
     void maxPointCloudRangeChanged(double range);
 
@@ -357,11 +357,11 @@ private:
 
     //
     // Timestamping and timesync settings
-    ros::Time convertImageTimestamp(uint32_t time_secs, uint32_t time_microsecs);
+    ros::Time imageTimestampToRosTime(uint32_t time_secs, uint32_t time_microsecs);
 
     bool ptp_time_sync_ = false;
     bool network_time_sync_ = false;
-    std::atomic_bool ptp_status_;
+    std::atomic_bool ptp_time_stamp_in_use_;
     int32_t ptp_time_offset_secs_ = 0;
 };
 

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -359,7 +359,7 @@ private:
     bool ptp_time_sync_ = false;
     bool network_time_sync_ = false;
 
-    int32_t ptp_time_offset_sec_ = 0;
+    int32_t ptp_time_offset_secs_ = 0;
 };
 
 }

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -350,6 +350,7 @@ private:
     diagnostic_updater::Updater diagnostic_updater_;
     void deviceInfoDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
     void deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    void ptpStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat);
 
     void diagnosticTimerCallback(const ros::TimerEvent &);
     ros::Timer diagnostic_trigger_;
@@ -358,7 +359,7 @@ private:
     // Timesync settings
     bool ptp_time_sync_ = false;
     bool network_time_sync_ = false;
-
+    std::atomic_bool ptp_status_;
     int32_t ptp_time_offset_secs_ = 0;
 };
 

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -353,6 +353,13 @@ private:
 
     void diagnosticTimerCallback(const ros::TimerEvent &);
     ros::Timer diagnostic_trigger_;
+
+    //
+    // Timesync settings
+    bool ptp_time_sync_ = false;
+    bool network_time_sync_ = false;
+
+    int32_t ptp_time_offset_sec_ = 0;
 };
 
 }

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -320,6 +320,12 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
     }
 
     //
+    // Get timesync parameters
+    device_nh_.getParam("ptp_time_offset_sec", ptp_time_offset_sec_);
+    device_nh_.getParam("ptp_time_sync", ptp_time_sync_);
+    device_nh_.getParam("network_time_sync", network_time_sync_);
+
+    //
     // Get the camera config
 
     image::Config image_config;
@@ -827,8 +833,18 @@ void Camera::histogramCallback(const image::Header& header)
         Status status = driver_->getImageHistogram(header.frameId, mh);
         if (Status_Ok == status) {
             rh.frame_count = header.frameId;
-            rh.time_stamp  = ros::Time(header.timeSeconds,
-                                       1000 * header.timeMicroSeconds);
+            rh.time_stamp  = ros::Time::now();
+
+            if (header.timeSeconds != 0)
+            {
+                rh.time_stamp = ros::Time(header.timeSeconds,
+                    1000 * header.timeMicroSeconds);
+                if (ptp_time_sync_ && !network_time_sync_)
+                {
+                    rh.time_stamp += ros::Duration(ptp_time_offset_sec_);
+                }
+            }
+
             rh.width  = header.width;
             rh.height = header.height;
             switch(header.source) {
@@ -859,6 +875,10 @@ void Camera::jpegImageCallback(const image::Header& header)
     if (header.timeSeconds != 0)
     {
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+        if (ptp_time_sync_ && !network_time_sync_)
+        {
+            t += ros::Duration(ptp_time_offset_sec_);
+        }
     }
 
     const uint32_t height    = header.height;
@@ -933,6 +953,10 @@ void Camera::disparityImageCallback(const image::Header& header)
     if (header.timeSeconds != 0)
     {
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+        if (ptp_time_sync_ && !network_time_sync_)
+        {
+            t += ros::Duration(ptp_time_offset_sec_);
+        }
     }
 
     switch(header.source) {
@@ -1106,6 +1130,10 @@ void Camera::monoCallback(const image::Header& header)
     if (header.timeSeconds != 0)
     {
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+        if (ptp_time_sync_ && !network_time_sync_)
+        {
+            t += ros::Duration(ptp_time_offset_sec_);
+        }
     }
 
     switch(header.source) {
@@ -1218,6 +1246,10 @@ void Camera::rectCallback(const image::Header& header)
     if (header.timeSeconds != 0)
     {
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+        if (ptp_time_sync_ && !network_time_sync_)
+        {
+            t += ros::Duration(ptp_time_offset_sec_);
+        }
     }
 
     switch(header.source) {
@@ -1354,6 +1386,10 @@ void Camera::depthCallback(const image::Header& header)
     if (header.timeSeconds != 0)
     {
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+        if (ptp_time_sync_ && !network_time_sync_)
+        {
+            t += ros::Duration(ptp_time_offset_sec_);
+        }
     }
 
     const float    bad_point = std::numeric_limits<float>::quiet_NaN();
@@ -1531,6 +1567,10 @@ void Camera::pointCloudCallback(const image::Header& header)
     if (header.timeSeconds != 0)
     {
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+        if (ptp_time_sync_ && !network_time_sync_)
+        {
+            t += ros::Duration(ptp_time_offset_sec_);
+        }
     }
 
     //
@@ -1784,9 +1824,19 @@ void Camera::rawCamDataCallback(const image::Header& header)
             raw_cam_data_.gain              = left_luma_rect.gain;
             raw_cam_data_.exposure_time     = left_luma_rect.exposure;
             raw_cam_data_.frame_count       = left_luma_rect.frameId;
-            raw_cam_data_.time_stamp        = ros::Time(left_luma_rect.timeSeconds, 1000 * left_luma_rect.timeMicroSeconds);
+            raw_cam_data_.time_stamp        = ros::Time::now();
             raw_cam_data_.width             = left_luma_rect.width;
             raw_cam_data_.height            = left_luma_rect.height;
+
+            if (left_luma_rect.timeSeconds != 0)
+            {
+                raw_cam_data_.time_stamp = ros::Time(header.timeSeconds,
+                    1000 * header.timeMicroSeconds);
+                if (ptp_time_sync_ && !network_time_sync_)
+                {
+                    raw_cam_data_.time_stamp += ros::Duration(ptp_time_offset_sec_);
+                }
+            }
 
             const uint32_t disparity_size = header.width * header.height;
 
@@ -1817,6 +1867,10 @@ void Camera::colorImageCallback(const image::Header& header)
     if (header.timeSeconds != 0)
     {
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+        if (ptp_time_sync_ && !network_time_sync_)
+        {
+            t += ros::Duration(ptp_time_offset_sec_);
+        }
     }
 
     switch (header.source)

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -302,7 +302,8 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
     pointcloud_max_range_(15.0),
     last_frame_id_(-1),
     border_clip_type_(BorderClip::NONE),
-    border_clip_value_(0.0)
+    border_clip_value_(0.0),
+    ptp_status_(false)
 {
     //
     // Query device and version information from sensor
@@ -741,6 +742,7 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
     diagnostic_updater_.setHardwareID(device_info_.name + " " + std::to_string(device_info_.hardwareRevision));
     diagnostic_updater_.add("device_info", this, &Camera::deviceInfoDiagnostic);
     diagnostic_updater_.add("device_status", this, &Camera::deviceStatusDiagnostic);
+    diagnostic_updater_.add("ptp_status", this, &Camera::ptpStatusDiagnostic);
     diagnostic_trigger_ = device_nh_.createTimer(ros::Duration(1), &Camera::diagnosticTimerCallback, this);
 }
 
@@ -842,6 +844,7 @@ void Camera::histogramCallback(const image::Header& header)
                 if (ptp_time_sync_ && !network_time_sync_)
                 {
                     rh.time_stamp += ros::Duration(ptp_time_offset_secs_);
+                    ptp_status_ = true;
                 }
             }
 
@@ -878,6 +881,7 @@ void Camera::jpegImageCallback(const image::Header& header)
         if (ptp_time_sync_ && !network_time_sync_)
         {
             t += ros::Duration(ptp_time_offset_secs_);
+            ptp_status_ = true;
         }
     }
 
@@ -956,6 +960,7 @@ void Camera::disparityImageCallback(const image::Header& header)
         if (ptp_time_sync_ && !network_time_sync_)
         {
             t += ros::Duration(ptp_time_offset_secs_);
+            ptp_status_ = true;
         }
     }
 
@@ -1133,6 +1138,7 @@ void Camera::monoCallback(const image::Header& header)
         if (ptp_time_sync_ && !network_time_sync_)
         {
             t += ros::Duration(ptp_time_offset_secs_);
+            ptp_status_ = true;
         }
     }
 
@@ -1249,6 +1255,7 @@ void Camera::rectCallback(const image::Header& header)
         if (ptp_time_sync_ && !network_time_sync_)
         {
             t += ros::Duration(ptp_time_offset_secs_);
+            ptp_status_ = true;
         }
     }
 
@@ -1389,6 +1396,7 @@ void Camera::depthCallback(const image::Header& header)
         if (ptp_time_sync_ && !network_time_sync_)
         {
             t += ros::Duration(ptp_time_offset_secs_);
+            ptp_status_ = true;
         }
     }
 
@@ -1570,6 +1578,7 @@ void Camera::pointCloudCallback(const image::Header& header)
         if (ptp_time_sync_ && !network_time_sync_)
         {
             t += ros::Duration(ptp_time_offset_secs_);
+            ptp_status_ = true;
         }
     }
 
@@ -1835,6 +1844,7 @@ void Camera::rawCamDataCallback(const image::Header& header)
                 if (ptp_time_sync_ && !network_time_sync_)
                 {
                     raw_cam_data_.time_stamp += ros::Duration(ptp_time_offset_secs_);
+                    ptp_status_ = true;
                 }
             }
 
@@ -1870,6 +1880,7 @@ void Camera::colorImageCallback(const image::Header& header)
         if (ptp_time_sync_ && !network_time_sync_)
         {
             t += ros::Duration(ptp_time_offset_secs_);
+            ptp_status_ = true;
         }
     }
 
@@ -2344,6 +2355,25 @@ void Camera::deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper&
     } else {
         stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "MultiSense Status: ERROR - Unable to retrieve status");
     }
+}
+
+void Camera::ptpStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat)
+{
+    stat.add("ptp enabled", ptp_time_sync_);
+    stat.add("ptp status", ptp_status_);
+    if (!ptp_time_sync_)
+    {
+        stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "PTP status: Disabled.");
+        return;
+    }
+
+    if (ptp_status_)
+    {
+        stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "PTP status: OK");
+    } else {
+        stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "PTP status: Uncalibrated");
+    }
+    ptp_status_ = false;
 }
 
 void Camera::diagnosticTimerCallback(const ros::TimerEvent&)

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -321,7 +321,7 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
 
     //
     // Get timesync parameters
-    device_nh_.getParam("ptp_time_offset_sec", ptp_time_offset_sec_);
+    device_nh_.getParam("ptp_time_offset_secs", ptp_time_offset_secs_);
     device_nh_.getParam("ptp_time_sync", ptp_time_sync_);
     device_nh_.getParam("network_time_sync", network_time_sync_);
 
@@ -841,7 +841,7 @@ void Camera::histogramCallback(const image::Header& header)
                     1000 * header.timeMicroSeconds);
                 if (ptp_time_sync_ && !network_time_sync_)
                 {
-                    rh.time_stamp += ros::Duration(ptp_time_offset_sec_);
+                    rh.time_stamp += ros::Duration(ptp_time_offset_secs_);
                 }
             }
 
@@ -877,7 +877,7 @@ void Camera::jpegImageCallback(const image::Header& header)
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
         if (ptp_time_sync_ && !network_time_sync_)
         {
-            t += ros::Duration(ptp_time_offset_sec_);
+            t += ros::Duration(ptp_time_offset_secs_);
         }
     }
 
@@ -955,7 +955,7 @@ void Camera::disparityImageCallback(const image::Header& header)
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
         if (ptp_time_sync_ && !network_time_sync_)
         {
-            t += ros::Duration(ptp_time_offset_sec_);
+            t += ros::Duration(ptp_time_offset_secs_);
         }
     }
 
@@ -1132,7 +1132,7 @@ void Camera::monoCallback(const image::Header& header)
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
         if (ptp_time_sync_ && !network_time_sync_)
         {
-            t += ros::Duration(ptp_time_offset_sec_);
+            t += ros::Duration(ptp_time_offset_secs_);
         }
     }
 
@@ -1248,7 +1248,7 @@ void Camera::rectCallback(const image::Header& header)
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
         if (ptp_time_sync_ && !network_time_sync_)
         {
-            t += ros::Duration(ptp_time_offset_sec_);
+            t += ros::Duration(ptp_time_offset_secs_);
         }
     }
 
@@ -1388,7 +1388,7 @@ void Camera::depthCallback(const image::Header& header)
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
         if (ptp_time_sync_ && !network_time_sync_)
         {
-            t += ros::Duration(ptp_time_offset_sec_);
+            t += ros::Duration(ptp_time_offset_secs_);
         }
     }
 
@@ -1569,7 +1569,7 @@ void Camera::pointCloudCallback(const image::Header& header)
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
         if (ptp_time_sync_ && !network_time_sync_)
         {
-            t += ros::Duration(ptp_time_offset_sec_);
+            t += ros::Duration(ptp_time_offset_secs_);
         }
     }
 
@@ -1834,7 +1834,7 @@ void Camera::rawCamDataCallback(const image::Header& header)
                     1000 * header.timeMicroSeconds);
                 if (ptp_time_sync_ && !network_time_sync_)
                 {
-                    raw_cam_data_.time_stamp += ros::Duration(ptp_time_offset_sec_);
+                    raw_cam_data_.time_stamp += ros::Duration(ptp_time_offset_secs_);
                 }
             }
 
@@ -1869,7 +1869,7 @@ void Camera::colorImageCallback(const image::Header& header)
         t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
         if (ptp_time_sync_ && !network_time_sync_)
         {
-            t += ros::Duration(ptp_time_offset_sec_);
+            t += ros::Duration(ptp_time_offset_secs_);
         }
     }
 

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -855,7 +855,11 @@ void Camera::jpegImageCallback(const image::Header& header)
         return;
     }
 
-    const ros::Time t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    ros::Time t = ros::Time::now();
+    if (header.timeSeconds != 0)
+    {
+        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    }
 
     const uint32_t height    = header.height;
     const uint32_t width     = header.width;
@@ -925,7 +929,11 @@ void Camera::disparityImageCallback(const image::Header& header)
 
     const uint32_t imageSize = (header.width * header.height * header.bitsPerPixel) / 8;
 
-    const ros::Time t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    ros::Time t = ros::Time::now();
+    if (header.timeSeconds != 0)
+    {
+        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    }
 
     switch(header.source) {
     case Source_Disparity:
@@ -1094,7 +1102,11 @@ void Camera::monoCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    ros::Time t = ros::Time::now();
+    if (header.timeSeconds != 0)
+    {
+        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    }
 
     switch(header.source) {
     case Source_Luma_Left:
@@ -1202,7 +1214,11 @@ void Camera::rectCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    ros::Time t = ros::Time::now();
+    if (header.timeSeconds != 0)
+    {
+        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    }
 
     switch(header.source) {
     case Source_Luma_Rectified_Left:
@@ -1334,7 +1350,11 @@ void Camera::depthCallback(const image::Header& header)
         return;
     }
 
-    const ros::Time t(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    ros::Time t = ros::Time::now();
+    if (header.timeSeconds != 0)
+    {
+        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    }
 
     const float    bad_point = std::numeric_limits<float>::quiet_NaN();
     const uint32_t depthSize = header.height * header.width * sizeof(float);
@@ -1507,7 +1527,11 @@ void Camera::pointCloudCallback(const image::Header& header)
         return;
     }
 
-    const ros::Time t(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    ros::Time t = ros::Time::now();
+    if (header.timeSeconds != 0)
+    {
+        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    }
 
     //
     // Resize our corresponding pointclouds if we plan on publishing them
@@ -1789,7 +1813,11 @@ void Camera::colorImageCallback(const image::Header& header)
         return;
     }
 
-    const ros::Time t(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    ros::Time t = ros::Time::now();
+    if (header.timeSeconds != 0)
+    {
+        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
+    }
 
     switch (header.source)
     {

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -835,19 +835,7 @@ void Camera::histogramCallback(const image::Header& header)
         Status status = driver_->getImageHistogram(header.frameId, mh);
         if (Status_Ok == status) {
             rh.frame_count = header.frameId;
-            rh.time_stamp  = ros::Time::now();
-
-            if (header.timeSeconds != 0)
-            {
-                rh.time_stamp = ros::Time(header.timeSeconds,
-                    1000 * header.timeMicroSeconds);
-                if (ptp_time_sync_ && !network_time_sync_)
-                {
-                    rh.time_stamp += ros::Duration(ptp_time_offset_secs_);
-                    ptp_status_ = true;
-                }
-            }
-
+            rh.time_stamp = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
             rh.width  = header.width;
             rh.height = header.height;
             switch(header.source) {
@@ -874,16 +862,7 @@ void Camera::jpegImageCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = ros::Time::now();
-    if (header.timeSeconds != 0)
-    {
-        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
-        if (ptp_time_sync_ && !network_time_sync_)
-        {
-            t += ros::Duration(ptp_time_offset_secs_);
-            ptp_status_ = true;
-        }
-    }
+    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
 
     const uint32_t height    = header.height;
     const uint32_t width     = header.width;
@@ -953,16 +932,7 @@ void Camera::disparityImageCallback(const image::Header& header)
 
     const uint32_t imageSize = (header.width * header.height * header.bitsPerPixel) / 8;
 
-    ros::Time t = ros::Time::now();
-    if (header.timeSeconds != 0)
-    {
-        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
-        if (ptp_time_sync_ && !network_time_sync_)
-        {
-            t += ros::Duration(ptp_time_offset_secs_);
-            ptp_status_ = true;
-        }
-    }
+    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
 
     switch(header.source) {
     case Source_Disparity:
@@ -1131,16 +1101,7 @@ void Camera::monoCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = ros::Time::now();
-    if (header.timeSeconds != 0)
-    {
-        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
-        if (ptp_time_sync_ && !network_time_sync_)
-        {
-            t += ros::Duration(ptp_time_offset_secs_);
-            ptp_status_ = true;
-        }
-    }
+    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
 
     switch(header.source) {
     case Source_Luma_Left:
@@ -1248,16 +1209,7 @@ void Camera::rectCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = ros::Time::now();
-    if (header.timeSeconds != 0)
-    {
-        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
-        if (ptp_time_sync_ && !network_time_sync_)
-        {
-            t += ros::Duration(ptp_time_offset_secs_);
-            ptp_status_ = true;
-        }
-    }
+    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
 
     switch(header.source) {
     case Source_Luma_Rectified_Left:
@@ -1389,16 +1341,7 @@ void Camera::depthCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = ros::Time::now();
-    if (header.timeSeconds != 0)
-    {
-        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
-        if (ptp_time_sync_ && !network_time_sync_)
-        {
-            t += ros::Duration(ptp_time_offset_secs_);
-            ptp_status_ = true;
-        }
-    }
+    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
 
     const float    bad_point = std::numeric_limits<float>::quiet_NaN();
     const uint32_t depthSize = header.height * header.width * sizeof(float);
@@ -1571,16 +1514,7 @@ void Camera::pointCloudCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = ros::Time::now();
-    if (header.timeSeconds != 0)
-    {
-        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
-        if (ptp_time_sync_ && !network_time_sync_)
-        {
-            t += ros::Duration(ptp_time_offset_secs_);
-            ptp_status_ = true;
-        }
-    }
+    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
 
     //
     // Resize our corresponding pointclouds if we plan on publishing them
@@ -1833,20 +1767,9 @@ void Camera::rawCamDataCallback(const image::Header& header)
             raw_cam_data_.gain              = left_luma_rect.gain;
             raw_cam_data_.exposure_time     = left_luma_rect.exposure;
             raw_cam_data_.frame_count       = left_luma_rect.frameId;
-            raw_cam_data_.time_stamp        = ros::Time::now();
+            raw_cam_data_.time_stamp        = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
             raw_cam_data_.width             = left_luma_rect.width;
             raw_cam_data_.height            = left_luma_rect.height;
-
-            if (left_luma_rect.timeSeconds != 0)
-            {
-                raw_cam_data_.time_stamp = ros::Time(header.timeSeconds,
-                    1000 * header.timeMicroSeconds);
-                if (ptp_time_sync_ && !network_time_sync_)
-                {
-                    raw_cam_data_.time_stamp += ros::Duration(ptp_time_offset_secs_);
-                    ptp_status_ = true;
-                }
-            }
 
             const uint32_t disparity_size = header.width * header.height;
 
@@ -1873,16 +1796,7 @@ void Camera::colorImageCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = ros::Time::now();
-    if (header.timeSeconds != 0)
-    {
-        t = ros::Time(header.timeSeconds, 1000 * header.timeMicroSeconds);
-        if (ptp_time_sync_ && !network_time_sync_)
-        {
-            t += ros::Duration(ptp_time_offset_secs_);
-            ptp_status_ = true;
-        }
-    }
+    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
 
     switch (header.source)
     {
@@ -2171,6 +2085,25 @@ void Camera::groundSurfaceSplineCallback(const ground_surface::Header& header)
 
     // Send pointcloud message
     ground_surface_spline_pub_.publish(ground_surface_utilities::eigenToPointcloud(eigen_pcl, frame_id_origin_));
+}
+
+ros::Time Camera::convertImageTimestamp(uint32_t time_secs, uint32_t time_microsecs)
+{
+    // When camera has ptp enabled and there is no ptp lock,
+    // the image timestamp equals 0
+    if (time_secs == 0)
+    {
+        return ros::Time::now();
+    }
+
+    auto time_stamp = ros::Time(time_secs, 1000 * time_microsecs);
+    if (ptp_time_sync_ && time_secs > std::abs(ptp_time_offset_secs_))
+    {
+        time_stamp += ros::Duration(ptp_time_offset_secs_);
+        ptp_status_ = true;
+    }
+
+    return time_stamp;
 }
 
 void Camera::updateConfig(const image::Config& config)

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -303,7 +303,7 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
     last_frame_id_(-1),
     border_clip_type_(BorderClip::NONE),
     border_clip_value_(0.0),
-    ptp_status_(false)
+    ptp_time_stamp_in_use_(false)
 {
     //
     // Query device and version information from sensor
@@ -835,7 +835,7 @@ void Camera::histogramCallback(const image::Header& header)
         Status status = driver_->getImageHistogram(header.frameId, mh);
         if (Status_Ok == status) {
             rh.frame_count = header.frameId;
-            rh.time_stamp = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+            rh.time_stamp = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
             rh.width  = header.width;
             rh.height = header.height;
             switch(header.source) {
@@ -862,7 +862,7 @@ void Camera::jpegImageCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+    ros::Time t = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
 
     const uint32_t height    = header.height;
     const uint32_t width     = header.width;
@@ -932,7 +932,7 @@ void Camera::disparityImageCallback(const image::Header& header)
 
     const uint32_t imageSize = (header.width * header.height * header.bitsPerPixel) / 8;
 
-    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+    ros::Time t = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
 
     switch(header.source) {
     case Source_Disparity:
@@ -1101,7 +1101,7 @@ void Camera::monoCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+    ros::Time t = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
 
     switch(header.source) {
     case Source_Luma_Left:
@@ -1209,7 +1209,7 @@ void Camera::rectCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+    ros::Time t = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
 
     switch(header.source) {
     case Source_Luma_Rectified_Left:
@@ -1341,7 +1341,7 @@ void Camera::depthCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+    ros::Time t = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
 
     const float    bad_point = std::numeric_limits<float>::quiet_NaN();
     const uint32_t depthSize = header.height * header.width * sizeof(float);
@@ -1514,7 +1514,7 @@ void Camera::pointCloudCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+    ros::Time t = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
 
     //
     // Resize our corresponding pointclouds if we plan on publishing them
@@ -1767,7 +1767,7 @@ void Camera::rawCamDataCallback(const image::Header& header)
             raw_cam_data_.gain              = left_luma_rect.gain;
             raw_cam_data_.exposure_time     = left_luma_rect.exposure;
             raw_cam_data_.frame_count       = left_luma_rect.frameId;
-            raw_cam_data_.time_stamp        = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+            raw_cam_data_.time_stamp        = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
             raw_cam_data_.width             = left_luma_rect.width;
             raw_cam_data_.height            = left_luma_rect.height;
 
@@ -1796,7 +1796,7 @@ void Camera::colorImageCallback(const image::Header& header)
         return;
     }
 
-    ros::Time t = convertImageTimestamp(header.timeSeconds, header.timeMicroSeconds);
+    ros::Time t = imageTimestampToRosTime(header.timeSeconds, header.timeMicroSeconds);
 
     switch (header.source)
     {
@@ -2087,7 +2087,7 @@ void Camera::groundSurfaceSplineCallback(const ground_surface::Header& header)
     ground_surface_spline_pub_.publish(ground_surface_utilities::eigenToPointcloud(eigen_pcl, frame_id_origin_));
 }
 
-ros::Time Camera::convertImageTimestamp(uint32_t time_secs, uint32_t time_microsecs)
+ros::Time Camera::imageTimestampToRosTime(uint32_t time_secs, uint32_t time_microsecs)
 {
     // When camera has ptp enabled and there is no ptp lock,
     // the image timestamp equals 0
@@ -2100,7 +2100,7 @@ ros::Time Camera::convertImageTimestamp(uint32_t time_secs, uint32_t time_micros
     if (ptp_time_sync_ && time_secs > std::abs(ptp_time_offset_secs_))
     {
         time_stamp += ros::Duration(ptp_time_offset_secs_);
-        ptp_status_ = true;
+        ptp_time_stamp_in_use_ = true;
     }
 
     return time_stamp;
@@ -2293,20 +2293,20 @@ void Camera::deviceStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper&
 void Camera::ptpStatusDiagnostic(diagnostic_updater::DiagnosticStatusWrapper& stat)
 {
     stat.add("ptp enabled", ptp_time_sync_);
-    stat.add("ptp status", ptp_status_);
+    stat.add("ptp status",  ptp_time_stamp_in_use_);
     if (!ptp_time_sync_)
     {
         stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "PTP status: Disabled.");
         return;
     }
 
-    if (ptp_status_)
+    if (ptp_time_stamp_in_use_)
     {
         stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "PTP status: OK");
     } else {
         stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "PTP status: Uncalibrated");
     }
-    ptp_status_ = false;
+    ptp_time_stamp_in_use_ = false;
 }
 
 void Camera::diagnosticTimerCallback(const ros::TimerEvent&)


### PR DESCRIPTION
Summary:
- Account for PTP timestamps being 0 before valid ptp lock.
- Add optional ptp time offset parameter.
- Add ptp status diagnostic.

Test plan:
- Tested with multi-camera S27 setup with phc2sys and ptp4l services.