### PR TITLE
Support on-camera apriltag detections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # multisense_ros
 
-Wrappers, drivers, tools and additional API's for using MultiSense SL, S7, S7S, S21, M, ST21, and BCAM  with ROS.
+Wrappers, drivers, tools and additional API's for using MultiSense S27, S30, KS21, SL, S7, S7S, S21, M, ST21, BCAM  with ROS.
 
 ### Installation, Documentation and Tutorials
-[Installing multisense_ros](http://docs.carnegierobotics.com/SL/install.html#install)
+
+See the following for documentation on on installing and using multisense_ros for specific camera types.
+
+- [S27](https://docs.carnegierobotics.com/S27/index.html)
+- [S30](https://docs.carnegierobotics.com/S30/index.html)
+- [KS21](https://docs.carnegierobotics.com/KS21/index.html)
+- [S21](https://docs.carnegierobotics.com/S21/index.html)
+- [S7/S7S](https://docs.carnegierobotics.com/S7/index.html)
+- [SL](https://docs.carnegierobotics.com/SL/index.html)
+
+Please see the following link for detailed documentation on the [LibMultiSense API](https://docs.carnegierobotics.com/libmultisense/index.html) wrapped by the ROS driver.
 
 ### Develop and Contribute
 

--- a/multisense_bringup/CMakeLists.txt
+++ b/multisense_bringup/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 install(FILES
   rviz_config.rviz
   multisense.launch
+  remote_head.launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/multisense_bringup/multisense.launch
+++ b/multisense_bringup/multisense.launch
@@ -1,11 +1,13 @@
 <launch>
 
-  <!-- Valid Sensor types are SL, S7, S7S, S21, S27, and BCAM -->
+  <!-- Valid Sensor types are SL, S7, S7S, S21, S27, BCAM,
+                              remote_head_vpb, remote_head_stereo, remote_head_monocam -->
 
   <arg name="ip_address" default="10.66.171.21" />
   <arg name="namespace"  default="multisense" />
   <arg name="mtu"        default="7200" />
   <arg name="sensor"     default="S21" />
+  <arg name="head_id"    default="-1" />
   <arg name="launch_robot_state_publisher" default="true" />
   <arg name="launch_color_laser_publisher" default="false" />
   <arg name="nodes_prefix" default="$(arg namespace)" />
@@ -26,6 +28,7 @@
      <param name="sensor_ip"   value="$(arg ip_address)" />
      <param name="sensor_mtu"  value="$(arg mtu)" />
      <param name="tf_prefix"  value="$(arg tf_prefix)" />
+     <param name="head_id"  value="$(arg head_id)" />
   </node>
 
   <!-- Color Laser PointCloud Publisher -->

--- a/multisense_bringup/remote_head.launch
+++ b/multisense_bringup/remote_head.launch
@@ -1,0 +1,158 @@
+<launch>
+
+  <arg name="ip_address" default="10.66.171.21" />
+  <arg name="mtu"        default="7200" />
+
+  <arg name="launch_vpb" default="true" />
+  <arg name="launch_head0" default="true" />
+  <arg name="launch_head1" default="true" />
+  <arg name="launch_head2" default="true" />
+  <arg name="launch_head3" default="true" />
+
+  <arg name="vpb_namespace"    default="multisense_vpb" />
+  <arg name="head0_namespace"  default="remote_head_0" />
+  <arg name="head1_namespace"  default="remote_head_1" />
+  <arg name="head2_namespace"  default="remote_head_2" />
+  <arg name="head3_namespace"  default="remote_head_3" />
+
+  <!-- Valid Sensor types for remote heads are remote_head_vpb, remote_head_stereo, remote_head_monocam -->
+  <arg name="vpb_sensor"       default="remote_head_vpb" />
+  <arg name="head0_sensor"     default="remote_head_stereo" />
+  <arg name="head1_sensor"     default="remote_head_stereo" />
+  <arg name="head2_sensor"     default="remote_head_stereo" />
+  <arg name="head3_sensor"     default="remote_head_stereo" />
+
+  <arg name="vpb_nodes_prefix"   default="$(arg vpb_namespace)" />
+  <arg name="head0_nodes_prefix" default="$(arg head0_namespace)" />
+  <arg name="head1_nodes_prefix" default="$(arg head1_namespace)" />
+  <arg name="head2_nodes_prefix" default="$(arg head2_namespace)" />
+  <arg name="head3_nodes_prefix" default="$(arg head3_namespace)" />
+
+  <arg name="vpb_tf_prefix"   default="$(arg vpb_namespace)" />
+  <arg name="head0_tf_prefix" default="$(arg head0_namespace)" />
+  <arg name="head1_tf_prefix" default="$(arg head1_namespace)" />
+  <arg name="head2_tf_prefix" default="$(arg head2_namespace)" />
+  <arg name="head3_tf_prefix" default="$(arg head3_namespace)" />
+
+  <arg name="launch_robot_state_publisher" default="true" />
+
+  <!-- Remote Head VPB Launch-->
+  <group if = "$(arg launch_vpb)">
+
+    <!-- ROS Driver -->
+    <node pkg="multisense_ros" ns="$(arg vpb_namespace)" type="ros_driver" name="$(arg vpb_nodes_prefix)_driver" output="screen">
+      <param name="sensor_ip" value="$(arg ip_address)" />
+      <param name="sensor_mtu" value="$(arg mtu)" />
+      <param name="tf_prefix"  value="$(arg vpb_tf_prefix)" />
+      <param name="head_id"  value="-1" />
+    </node>
+
+    <!-- Robot state publisher -->
+    <group if = "$(arg launch_robot_state_publisher)">
+      <param name="robot_description"
+            command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg vpb_sensor)/standalone.urdf.xacro' name:=$(arg vpb_namespace)"/>
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg vpb_nodes_prefix)_state_publisher">
+        <param name="publish_frequency" type="double" value="50.0" />
+        <remap from="joint_states" to="/$(arg vpb_namespace)/joint_states" />
+      </node>
+    </group>
+
+  </group>
+
+
+  <!-- Remote Head 0 Launch -->
+  <group if = "$(arg launch_head0)">
+
+    <!-- ROS Driver -->
+    <node pkg="multisense_ros" ns="$(arg head0_namespace)" type="ros_driver" name="$(arg head0_nodes_prefix)_driver" output="screen">
+      <param name="sensor_ip" value="$(arg ip_address)" />
+      <param name="sensor_mtu" value="$(arg mtu)" />
+      <param name="tf_prefix"  value="$(arg head0_tf_prefix)" />
+      <param name="head_id"  value="0" />
+    </node>
+
+    <!-- Robot state publisher -->
+    <group if = "$(arg launch_robot_state_publisher)">
+      <param name="robot_description"
+            command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg head0_sensor)/standalone.urdf.xacro' name:=$(arg head0_namespace)"/>
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head0_nodes_prefix)_state_publisher">
+        <param name="publish_frequency" type="double" value="50.0" />
+        <remap from="joint_states" to="/$(arg head0_namespace)/joint_states" />
+      </node>
+    </group>
+
+  </group>
+
+
+  <!-- Remote Head 1 Launch -->
+  <group if = "$(arg launch_head1)">
+
+    <!-- ROS Driver -->
+    <node pkg="multisense_ros" ns="$(arg head1_namespace)" type="ros_driver" name="$(arg head1_nodes_prefix)_driver" output="screen">
+      <param name="sensor_ip" value="$(arg ip_address)" />
+      <param name="sensor_mtu" value="$(arg mtu)" />
+      <param name="tf_prefix"  value="$(arg head1_tf_prefix)" />
+      <param name="head_id"  value="1" />
+    </node>
+
+    <!-- Robot state publisher -->
+    <group if = "$(arg launch_robot_state_publisher)">
+      <param name="robot_description"
+            command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg head1_sensor)/standalone.urdf.xacro' name:=$(arg head1_namespace)"/>
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head1_nodes_prefix)_state_publisher">
+        <param name="publish_frequency" type="double" value="50.0" />
+        <remap from="joint_states" to="/$(arg head1_namespace)/joint_states" />
+      </node>
+    </group>
+
+  </group>
+
+
+  <!-- Remote Head 2 Launch -->
+  <group if = "$(arg launch_head2)">
+
+    <!-- ROS Driver -->
+    <node pkg="multisense_ros" ns="$(arg head2_namespace)" type="ros_driver" name="$(arg head2_nodes_prefix)_driver" output="screen">
+      <param name="sensor_ip" value="$(arg ip_address)" />
+      <param name="sensor_mtu" value="$(arg mtu)" />
+      <param name="tf_prefix"  value="$(arg head2_tf_prefix)" />
+      <param name="head_id"  value="2" />
+    </node>
+
+    <!-- Robot state publisher -->
+    <group if = "$(arg launch_robot_state_publisher)">
+      <param name="robot_description"
+            command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg head2_sensor)/standalone.urdf.xacro' name:=$(arg head2_namespace)"/>
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head2_nodes_prefix)_state_publisher">
+        <param name="publish_frequency" type="double" value="50.0" />
+        <remap from="joint_states" to="/$(arg head2_namespace)/joint_states" />
+      </node>
+    </group>
+
+  </group>
+
+
+  <!-- Remote Head 3 Launch -->
+  <group if = "$(arg launch_head3)">
+
+    <!-- ROS Driver -->
+    <node pkg="multisense_ros" ns="$(arg head3_namespace)" type="ros_driver" name="$(arg head3_nodes_prefix)_driver" output="screen">
+      <param name="sensor_ip" value="$(arg ip_address)" />
+      <param name="sensor_mtu" value="$(arg mtu)" />
+      <param name="tf_prefix"  value="$(arg head3_tf_prefix)" />
+      <param name="head_id"  value="3" />
+    </node>
+
+    <!-- Robot state publisher -->
+    <group if = "$(arg launch_robot_state_publisher)">
+      <param name="robot_description"
+            command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg head3_sensor)/standalone.urdf.xacro' name:=$(arg head3_namespace)"/>
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head3_nodes_prefix)_state_publisher">
+        <param name="publish_frequency" type="double" value="50.0" />
+        <remap from="joint_states" to="/$(arg head3_namespace)/joint_states" />
+      </node>
+    </group>
+
+  </group>
+
+</launch>

--- a/multisense_description/meshes/multisense_remote_head_monocam.STL
+++ b/multisense_description/meshes/multisense_remote_head_monocam.STL
@@ -1,0 +1,86 @@
+solid model
+facet normal 0.0 0.0 -1.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 0.0 -20.0 0.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal 0.0 0.0 -1.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 20.0 0.0 0.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal -0.0 -1.0 -0.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 0.0 -20.0 0.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal -0.0 -1.0 -0.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 20.0 -20.0 20.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal 1.0 0.0 0.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 20.0 -20.0 20.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal 1.0 0.0 0.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 20.0 0.0 0.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+facet normal -0.0 -0.0 1.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 0.0 0.0 20.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal -0.0 -0.0 1.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 20.0 -20.0 20.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+facet normal -1.0 0.0 0.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 0.0 -20.0 0.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal -1.0 0.0 0.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 0.0 0.0 20.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal -0.0 1.0 0.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 20.0 0.0 0.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal -0.0 1.0 0.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 0.0 0.0 20.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+endsolid model

--- a/multisense_description/meshes/multisense_remote_head_stereo.STL
+++ b/multisense_description/meshes/multisense_remote_head_stereo.STL
@@ -1,0 +1,86 @@
+solid model
+facet normal 0.0 0.0 -1.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 0.0 -20.0 0.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal 0.0 0.0 -1.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 20.0 0.0 0.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal -0.0 -1.0 -0.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 0.0 -20.0 0.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal -0.0 -1.0 -0.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 20.0 -20.0 20.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal 1.0 0.0 0.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 20.0 -20.0 20.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal 1.0 0.0 0.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 20.0 0.0 0.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+facet normal -0.0 -0.0 1.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 0.0 0.0 20.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal -0.0 -0.0 1.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 20.0 -20.0 20.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+facet normal -1.0 0.0 0.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 0.0 -20.0 0.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal -1.0 0.0 0.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 0.0 0.0 20.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal -0.0 1.0 0.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 20.0 0.0 0.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal -0.0 1.0 0.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 0.0 0.0 20.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+endsolid model

--- a/multisense_description/meshes/multisense_remote_head_vpb.STL
+++ b/multisense_description/meshes/multisense_remote_head_vpb.STL
@@ -1,0 +1,86 @@
+solid model
+facet normal 0.0 0.0 -1.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 0.0 -20.0 0.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal 0.0 0.0 -1.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 20.0 0.0 0.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal -0.0 -1.0 -0.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 0.0 -20.0 0.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal -0.0 -1.0 -0.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 20.0 -20.0 20.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal 1.0 0.0 0.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 20.0 -20.0 20.0
+vertex 20.0 -20.0 0.0
+endloop
+endfacet
+facet normal 1.0 0.0 0.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 20.0 0.0 0.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+facet normal -0.0 -0.0 1.0
+outer loop
+vertex 20.0 -20.0 20.0
+vertex 0.0 0.0 20.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal -0.0 -0.0 1.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 20.0 -20.0 20.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+facet normal -1.0 0.0 0.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 0.0 -20.0 0.0
+vertex 0.0 -20.0 20.0
+endloop
+endfacet
+facet normal -1.0 0.0 0.0
+outer loop
+vertex 0.0 -20.0 0.0
+vertex 0.0 0.0 20.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal -0.0 1.0 0.0
+outer loop
+vertex 0.0 0.0 20.0
+vertex 20.0 0.0 0.0
+vertex 0.0 0.0 0.0
+endloop
+endfacet
+facet normal -0.0 1.0 0.0
+outer loop
+vertex 20.0 0.0 0.0
+vertex 0.0 0.0 20.0
+vertex 20.0 0.0 20.0
+endloop
+endfacet
+endsolid model

--- a/multisense_description/urdf/multisenseremote_head_monocam/importable.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_monocam/importable.urdf.xacro
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find multisense_description)/urdf/multisenseremote_head_monocam/multisense_remote_head_monocam.urdf.xacro"/>
+
+  <xacro:macro name="importable_multisense_remote_head_monocam" params="parent name *origin">
+
+    <!-- Joint for connection to parent -->
+    <joint name="${name}_head_root_joint" type="fixed">
+      <insert_block name="origin"/>
+      <parent link="${parent}"/>
+      <child link="${name}/head"/>
+    </joint>
+
+    <xacro:multisense_remote_head_monocam name="${name}" />
+
+  </xacro:macro>
+</robot>
+

--- a/multisense_description/urdf/multisenseremote_head_monocam/multisense_remote_head_monocam.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_monocam/multisense_remote_head_monocam.urdf.xacro
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:macro name="multisense_remote_head_monocam" params="name">
+
+        <link name="${name}/head">
+            <visual>
+                <origin xyz="0 0 0" rpy="1.57079632679 0 1.57079632679" />
+                <geometry>
+                    <mesh filename="package://multisense_description/meshes/multisense_remote_head_monocam.STL"/>
+                </geometry>
+                <material name="">
+                    <color rgba="0.9098 0.44314 0.031373 1" />
+                </material>
+            </visual>
+        </link>
+
+        <!-- Note the origin of model is 37.3854mm from the rear mounting plane
+             in the x axis -->
+
+        <!-- Left camera optical frame is treated as the camera origin -->
+        <joint name="${name}/head_joint" type="fixed">
+            <origin xyz="0.105 0 -0.0052046" rpy="0.0 -1.57079632679 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
+        </joint>
+
+        <link name="${name}/left_camera_optical_frame"/>
+
+        <joint name="${name}/top_left_rear_mount_joint" type="fixed">
+            <origin xyz="-0.0373854 0.1 0.014" rpy="0 0 3.14159"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/top_left_rear_mount"/>
+        </joint>
+
+        <link name="${name}/top_left_rear_mount"/>
+
+        <!--Note the locations of the accel/mag and gyro differ from those shown
+            in CAD. The S21 firmware switches axis on the accel/mag and gyro to
+            match the S7/S7S/SL MultiSense configurations -->
+
+        <joint name="${name}/accel_joint" type="fixed">
+            <origin xyz="0.0045 0.029 -0.0135" rpy="0.0 1.57079632679 0.0"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/accel"/>
+        </joint>
+
+        <link name="${name}/accel"/>
+
+        <joint name="${name}/mag_joint" type="fixed">
+            <origin xyz="0.0045 0.029 -0.0135" rpy="0.0 1.57079632679 0.0"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/mag"/>
+        </joint>
+
+        <link name="${name}/mag"/>
+
+        <joint name="${name}/gyro_joint" type="fixed">
+            <origin xyz="-0.00219539 0.03758 -0.014" rpy="-1.57079632679 0 -1.57079632679"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/gyro"/>
+        </joint>
+
+        <link name="${name}/gyro"/>
+
+    </xacro:macro>
+
+</robot>
+

--- a/multisense_description/urdf/multisenseremote_head_monocam/standalone.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_monocam/standalone.urdf.xacro
@@ -1,0 +1,6 @@
+<robot name="multisense" xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:include filename="$(find multisense_description)/urdf/multisenseremote_head_monocam/multisense_remote_head_monocam.urdf.xacro"/>
+
+    <xacro:multisense_remote_head_monocam name="$(arg name)"/>
+</robot>
+

--- a/multisense_description/urdf/multisenseremote_head_stereo/importable.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_stereo/importable.urdf.xacro
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find multisense_description)/urdf/multisenseremote_head_stereo/multisense_remote_head_stereo.urdf.xacro"/>
+
+  <xacro:macro name="importable_multisense_remote_head_stereo" params="parent name *origin">
+
+    <!-- Joint for connection to parent -->
+    <joint name="${name}_head_root_joint" type="fixed">
+      <insert_block name="origin"/>
+      <parent link="${parent}"/>
+      <child link="${name}/head"/>
+    </joint>
+
+    <xacro:multisense_remote_head_stereo name="${name}" />
+
+  </xacro:macro>
+</robot>
+

--- a/multisense_description/urdf/multisenseremote_head_stereo/multisense_remote_head_stereo.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_stereo/multisense_remote_head_stereo.urdf.xacro
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:macro name="multisense_remote_head_stereo" params="name">
+
+        <link name="${name}/head">
+            <visual>
+                <origin xyz="0 0 0" rpy="1.57079632679 0 1.57079632679" />
+                <geometry>
+                    <mesh filename="package://multisense_description/meshes/multisense_remote_head_stereo.STL"/>
+                </geometry>
+                <material name="">
+                    <color rgba="0.9098 0.44314 0.031373 1" />
+                </material>
+            </visual>
+        </link>
+
+        <!-- Note the origin of model is 37.3854mm from the rear mounting plane
+             in the x axis -->
+
+        <!-- Left camera optical frame is treated as the camera origin -->
+        <joint name="${name}/head_joint" type="fixed">
+            <origin xyz="0.105 0 -0.0052046" rpy="0.0 -1.57079632679 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
+        </joint>
+
+        <link name="${name}/left_camera_optical_frame"/>
+
+        <joint name="${name}/top_left_rear_mount_joint" type="fixed">
+            <origin xyz="-0.0373854 0.1 0.014" rpy="0 0 3.14159"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/top_left_rear_mount"/>
+        </joint>
+
+        <link name="${name}/top_left_rear_mount"/>
+
+        <!--Note the locations of the accel/mag and gyro differ from those shown
+            in CAD. The S21 firmware switches axis on the accel/mag and gyro to
+            match the S7/S7S/SL MultiSense configurations -->
+
+        <joint name="${name}/accel_joint" type="fixed">
+            <origin xyz="0.0045 0.029 -0.0135" rpy="0.0 1.57079632679 0.0"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/accel"/>
+        </joint>
+
+        <link name="${name}/accel"/>
+
+        <joint name="${name}/mag_joint" type="fixed">
+            <origin xyz="0.0045 0.029 -0.0135" rpy="0.0 1.57079632679 0.0"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/mag"/>
+        </joint>
+
+        <link name="${name}/mag"/>
+
+        <joint name="${name}/gyro_joint" type="fixed">
+            <origin xyz="-0.00219539 0.03758 -0.014" rpy="-1.57079632679 0 -1.57079632679"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/gyro"/>
+        </joint>
+
+        <link name="${name}/gyro"/>
+
+    </xacro:macro>
+
+</robot>
+

--- a/multisense_description/urdf/multisenseremote_head_stereo/standalone.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_stereo/standalone.urdf.xacro
@@ -1,0 +1,6 @@
+<robot name="multisense" xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:include filename="$(find multisense_description)/urdf/multisenseremote_head_stereo/multisense_remote_head_stereo.urdf.xacro"/>
+
+    <xacro:multisense_remote_head_stereo name="$(arg name)"/>
+</robot>
+

--- a/multisense_description/urdf/multisenseremote_head_vpb/importable.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_vpb/importable.urdf.xacro
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find multisense_description)/urdf/multisenseremote_head_vpb/multisense_remote_head_vpb.urdf.xacro"/>
+
+  <xacro:macro name="importable_multisense_remote_head_vpb" params="parent name *origin">
+
+    <!-- Joint for connection to parent -->
+    <joint name="${name}_head_root_joint" type="fixed">
+      <insert_block name="origin"/>
+      <parent link="${parent}"/>
+      <child link="${name}/head"/>
+    </joint>
+
+    <xacro:multisense_remote_head_vpb name="${name}" />
+
+  </xacro:macro>
+</robot>
+

--- a/multisense_description/urdf/multisenseremote_head_vpb/multisense_remote_head_vpb.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_vpb/multisense_remote_head_vpb.urdf.xacro
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:macro name="multisense_remote_head_vpb" params="name">
+
+        <link name="${name}/head">
+            <visual>
+                <origin xyz="0 0 0" rpy="1.57079632679 0 1.57079632679" />
+                <geometry>
+                    <mesh filename="package://multisense_description/meshes/multisense_remote_head_vpb.STL"/>
+                </geometry>
+                <material name="">
+                    <color rgba="0.9098 0.44314 0.031373 1" />
+                </material>
+            </visual>
+        </link>
+
+        <!-- Note the origin of model is 37.3854mm from the rear mounting plane
+             in the x axis -->
+
+        <!-- Left camera optical frame is treated as the camera origin -->
+        <joint name="${name}/head_joint" type="fixed">
+            <origin xyz="0.105 0 -0.0052046" rpy="0.0 -1.57079632679 1.57079632679"/>
+            <parent link="${name}/left_camera_optical_frame"/>
+            <child link="${name}/head"/>
+        </joint>
+
+        <link name="${name}/left_camera_optical_frame"/>
+
+        <joint name="${name}/top_left_rear_mount_joint" type="fixed">
+            <origin xyz="-0.0373854 0.1 0.014" rpy="0 0 3.14159"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/top_left_rear_mount"/>
+        </joint>
+
+        <link name="${name}/top_left_rear_mount"/>
+
+        <!--Note the locations of the accel/mag and gyro differ from those shown
+            in CAD. The S21 firmware switches axis on the accel/mag and gyro to
+            match the S7/S7S/SL MultiSense configurations -->
+
+        <joint name="${name}/accel_joint" type="fixed">
+            <origin xyz="0.0045 0.029 -0.0135" rpy="0.0 1.57079632679 0.0"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/accel"/>
+        </joint>
+
+        <link name="${name}/accel"/>
+
+        <joint name="${name}/mag_joint" type="fixed">
+            <origin xyz="0.0045 0.029 -0.0135" rpy="0.0 1.57079632679 0.0"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/mag"/>
+        </joint>
+
+        <link name="${name}/mag"/>
+
+        <joint name="${name}/gyro_joint" type="fixed">
+            <origin xyz="-0.00219539 0.03758 -0.014" rpy="-1.57079632679 0 -1.57079632679"/>
+            <parent link="${name}/head"/>
+            <child link="${name}/gyro"/>
+        </joint>
+
+        <link name="${name}/gyro"/>
+
+    </xacro:macro>
+
+</robot>
+

--- a/multisense_description/urdf/multisenseremote_head_vpb/standalone.urdf.xacro
+++ b/multisense_description/urdf/multisenseremote_head_vpb/standalone.urdf.xacro
@@ -1,0 +1,6 @@
+<robot name="multisense" xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:include filename="$(find multisense_description)/urdf/multisenseremote_head_vpb/multisense_remote_head_vpb.urdf.xacro"/>
+
+    <xacro:multisense_remote_head_vpb name="$(arg name)"/>
+</robot>
+

--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -50,7 +50,10 @@ add_message_files(DIRECTORY msg
                   RawLidarCal.msg
                   Histogram.msg
                   DeviceStatus.msg
-                  StampedPps.msg)
+                  StampedPps.msg
+                  AprilTagCornerPoint.msg
+                  AprilTagDetection.msg
+                  AprilTagDetectionArray.msg)
 
 generate_messages(DEPENDENCIES sensor_msgs)
 

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -348,6 +348,7 @@ for feature_name, feature in SupportedFeatures.__members__.items():
                                              gen.const("tagStandard52h13", str_t, "tagStandard52h13", "tagStandard52h13")],
                                 "Available apriltag families")
             gen.add("apriltag_family", str_t, 0, "Apriltag family to detect", "tagStandard52h13", edit_method=apriltag_family_enum)
+            gen.add("apriltag_max_hamming", int_t, 0, "The maximum hamming correction that will be applied while detecting codes (value of 1 causes the detector to pause for a while)", 0, 0, 1)
             gen.add("apriltag_quad_detection_blur_sigma", double_t, 0, "Sigma of the Gaussian blur applied to the image before quad_detection, specified in full resolution pixels. Kernel size = 4*sigma, rounded up to the next odd number. (<0.5 results in no blur)", 0.75, 0.0, 5.0)
             gen.add("apriltag_quad_detection_decimate", double_t, 0, "Amount to decimate image before detecting quads. Values < 1.0. (0.5 decimation reduces height/width by half)", 1.0, 0.0, 1.0)
             gen.add("apriltag_min_border_width", int_t, 0, "Minimum border width that can be considered a valid tag. Used to filter contours based on area and perimeter. Units are in undecimated image pixels.", 5, 0, 10)

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -136,7 +136,7 @@ for feature_name, feature in SupportedFeatures.__members__.items():
                                 gen.const("1920x1200_256_disparities", str_t, "1920x1200x256", "1920x1200x256") ],
                                 "Available resolution settings")
             gen.add("resolution", str_t, 0, "sensor resolution", "960x600x256", edit_method=res_enum)
-            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 64.0)
+            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
             roi_width = 1920
             roi_height = 1200
             auto_exposure_threshold = 0.95

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -25,6 +25,7 @@ class SensorConfig(object):
 class SupportedFeatures(Enum):
     NONE = 0
     GROUND_SURFACE = 1
+    APRILTAG = 2
 
 sensorConfigList = []
 sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000",      sgm=False, motor=True,  imu=False, lighting=True , aux=False, ar0234=False, features=False))
@@ -231,7 +232,8 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             if feature == SupportedFeatures.GROUND_SURFACE:
                 gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
 
-            gen.add("apriltag_profile", bool_t, 0, "AprilTagProfile", False);
+            if feature == SupportedFeatures.APRILTAG:
+                gen.add("apriltag_profile", bool_t, 0, "AprilTagProfile", False);
 
             #endif
         #endif
@@ -332,6 +334,25 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             gen.add("ground_surface_max_fitting_iterations", int_t, 0, "ADVANCED SETTING: Number of iterations in B-spline routine", 10, 1, 30)
             gen.add("ground_surface_adjacent_cell_search_size_m", double_t, 0, "ADVANCED SETTING: Border size around obstacle cells to examine during iterative B-spline routine", 1.5, 0.0, 5.0)
             gen.add("ground_surface_spline_draw_resolution", double_t, 0, "Resolution to draw resulting B-Spline model with in RVIZ", 0.1, 0.01, 1.0)
+        #endif
+
+        if feature == SupportedFeatures.APRILTAG:
+            apriltag_family_enum = gen.enum([gen.const("tag25h9", str_t, "tag25h9", "tag25h9"),
+                                             gen.const("tag16h5", str_t, "tag16h5", "tag16h5"),
+                                             gen.const("tag36h10", str_t, "tag36h10", "tag36h10"),
+                                             gen.const("tag36h11", str_t, "tag36h11", "tag36h11"),
+                                             gen.const("tagCircle21h7", str_t, "tagCircle21h7", "tagCircle21h7"),
+                                             gen.const("tagCircle49h12", str_t, "tagCircle49h12", "tagCircle49h12"),
+                                             gen.const("tagCustom48h12", str_t, "tagCustom48h12", "tagCustom48h12"),
+                                             gen.const("tagStandard41h12", str_t, "tagStandard41h12", "tagStandard41h12"),
+                                             gen.const("tagStandard52h13", str_t, "tagStandard52h13", "tagStandard52h13")],
+                                "Available apriltag families")
+            gen.add("apriltag_family", str_t, 0, "Apriltag family to detect", "tagStandard52h13", edit_method=apriltag_family_enum)
+            gen.add("apriltag_quad_detection_blur_sigma", double_t, 0, "Sigma of the Gaussian blur applied to the image before quad_detection, specified in full resolution pixels. Kernel size = 4*sigma, rounded up to the next odd number. (<0.5 results in no blur)", 0.75, 0.0, 5.0)
+            gen.add("apriltag_quad_detection_decimate", double_t, 0, "Amount to decimate image before detecting quads. Values < 1.0. (0.5 decimation reduces height/width by half)", 1.0, 0.0, 1.0)
+            gen.add("apriltag_min_border_width", int_t, 0, "Minimum border width that can be considered a valid tag. Used to filter contours based on area and perimeter. Units are in undecimated image pixels.", 5, 0, 10)
+            gen.add("apriltag_refine_quad_edges", bool_t, 0, "Whether or not to refine the edges before attempting to decode", False)
+            gen.add("apriltag_decode_sharpening", double_t, 0, "How much to sharpen the quad before sampling the pixels. 0 to turn off, large values are stronger sharpening", 0.25, 0.0, 1.0)
         #endif
 
         # Generate package name based on camera cfg and supported features

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -230,6 +230,9 @@ for feature_name, feature in SupportedFeatures.__members__.items():
 
             if feature == SupportedFeatures.GROUND_SURFACE:
                 gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
+
+            gen.add("apriltag_profile", bool_t, 0, "AprilTagProfile", False);
+
             #endif
         #endif
 

--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -10,7 +10,7 @@ else:
     from dynamic_reconfigure.parameter_generator_catkin import *
 
 class SensorConfig(object):
-    def __init__(self, name=None, sgm=False, motor=False, imu=False, lighting=False, aux=False, ar0234=False, features=False):
+    def __init__(self, name=None, sgm=False, motor=False, imu=False, lighting=False, aux=False, ar0234=False, features=False, ptp=False):
         self.name     = name
         self.sgm      = sgm
         self.motor    = motor
@@ -19,6 +19,7 @@ class SensorConfig(object):
         self.aux      = aux
         self.ar0234   = ar0234
         self.features = features
+        self.ptp      = ptp
     #enddef
 #endclass
 
@@ -28,22 +29,28 @@ class SupportedFeatures(Enum):
     APRILTAG = 2
 
 sensorConfigList = []
-sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000",      sgm=False, motor=True,  imu=False, lighting=True , aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000_imu",  sgm=False, motor=True,  imu=True , lighting=True , aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="sl_bm_cmv4000",      sgm=False, motor=True,  imu=False, lighting=True , aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="sl_bm_cmv4000_imu",  sgm=False, motor=True,  imu=True , lighting=True , aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="sl_sgm_cmv2000_imu", sgm=True,  motor=True,  imu=True , lighting=True , aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="sl_sgm_cmv4000_imu", sgm=True,  motor=True,  imu=True , lighting=True , aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="st21_sgm_vga_imu",   sgm=True,  motor=False, imu=True , lighting=False, aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="mono_cmv2000",       sgm=False, motor=False, imu=True , lighting=True , aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="mono_cmv4000",       sgm=False, motor=False, imu=True , lighting=True , aux=False, ar0234=False, features=False))
-sensorConfigList.append(SensorConfig(name="s27_sgm_AR0234",     sgm=True,  motor=False, imu=False, lighting=False, aux=True,  ar0234=True , features=True))
-sensorConfigList.append(SensorConfig(name="ks21_sgm_AR0234",    sgm=True,  motor=False, imu=False, lighting=True , aux=False, ar0234=True , features=True))
+sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000",             sgm=False, motor=True,  imu=False, lighting=True,  aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="sl_bm_cmv2000_imu",         sgm=False, motor=True,  imu=True,  lighting=True,  aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="sl_bm_cmv4000",             sgm=False, motor=True,  imu=False, lighting=True,  aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="sl_bm_cmv4000_imu",         sgm=False, motor=True,  imu=True,  lighting=True,  aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="sl_sgm_cmv2000_imu",        sgm=True,  motor=True,  imu=True,  lighting=True,  aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="sl_sgm_cmv4000_imu",        sgm=True,  motor=True,  imu=True,  lighting=True,  aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="st21_sgm_vga_imu",          sgm=True,  motor=False, imu=True,  lighting=False, aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="mono_cmv2000",              sgm=False, motor=False, imu=True,  lighting=True,  aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="mono_cmv4000",              sgm=False, motor=False, imu=True,  lighting=True,  aux=False, ar0234=False, features=False, ptp=False))
+sensorConfigList.append(SensorConfig(name="s27_sgm_AR0234",            sgm=True,  motor=False, imu=False, lighting=False, aux=True,  ar0234=True,  features=True,  ptp=True))
+sensorConfigList.append(SensorConfig(name="ks21_sgm_AR0234",           sgm=True,  motor=False, imu=False, lighting=True,  aux=False, ar0234=True,  features=True,  ptp=True))
+sensorConfigList.append(SensorConfig(name="remote_head_vpb",           sgm=False, motor=False, imu=False, lighting=False, aux=False, ar0234=False, features=True,  ptp=True))
+sensorConfigList.append(SensorConfig(name="remote_head_sgm_AR0234",    sgm=True,  motor=False, imu=False, lighting=True,  aux=False, ar0234=True,  features=True,  ptp=True))
+sensorConfigList.append(SensorConfig(name="remote_head_monocam_AR0234",sgm=False, motor=False, imu=False, lighting=True,  aux=False, ar0234=True,  features=True,  ptp=True))
 
 for feature_name, feature in SupportedFeatures.__members__.items():
     for cfg in sensorConfigList:
         # Don't add feature config for unsupported cameras
         if not cfg.features and feature != SupportedFeatures.NONE:
+            continue
+        if feature == SupportedFeatures.GROUND_SURFACE and not cfg.sgm:
+            # ground surface requires stereo
             continue
 
         gen = ParameterGenerator()
@@ -131,13 +138,23 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             roi_width = 2048
             roi_height = 2048
         elif cfg.ar0234:
-            res_enum = gen.enum([ gen.const("960x600_256_disparities", str_t, "960x600x256", "960x600x256"),
-                                gen.const("1920x1200_64_disparities", str_t, "1920x1200x64", "1920x1200x64"),
-                                gen.const("1920x1200_128_disparities", str_t, "1920x1200x128", "1920x1200x128"),
-                                gen.const("1920x1200_256_disparities", str_t, "1920x1200x256", "1920x1200x256") ],
-                                "Available resolution settings")
-            gen.add("resolution", str_t, 0, "sensor resolution", "960x600x256", edit_method=res_enum)
-            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
+            if cfg.sgm:
+                # next gen stereo cameras
+                res_enum = gen.enum([ gen.const("960x600_256_disparities", str_t, "960x600x256", "960x600x256"),
+                                      gen.const("1920x1200_64_disparities", str_t, "1920x1200x64", "1920x1200x64"),
+                                      gen.const("1920x1200_128_disparities", str_t, "1920x1200x128", "1920x1200x128"),
+                                      gen.const("1920x1200_256_disparities", str_t, "1920x1200x256", "1920x1200x256") ],
+                                    "Available resolution settings")
+                gen.add("resolution", str_t, 0, "sensor resolution", "960x600x256", edit_method=res_enum)
+            else:
+                # next gen mono cameras have no dispairty settings
+                res_enum = gen.enum([ gen.const("960x600", str_t, "960x600x64", "960x600x64"),
+                                      gen.const("1920x1200", str_t, "1920x1200x64", "1920x1200x64") ],
+                                    "Available resolution settings")
+                gen.add("resolution", str_t, 0, "sensor resolution", "1920x1200x64", edit_method=res_enum)
+            #endif
+
+            gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 64.0)
             roi_width = 1920
             roi_height = 1200
             auto_exposure_threshold = 0.95
@@ -152,14 +169,23 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             gen.add("crop_offset", int_t, 0, "Crop Offset", 480, 0, 960)
         #endif
 
-        if cfg.name.find('st21_sgm_vga_imu') == -1:
+        if cfg.name.find('st21_sgm_vga_imu') == -1 and cfg.name.find('remote_head_vpb') == -1:
             gen.add("gain", double_t, 0, "SensorGain", 1.0, 1.0, 8.0)
             gen.add("auto_exposure", bool_t, 0, "AutoExposure", True)
-            gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.5, 0.0, 0.5);
+
+            if cfg.ar0234:
+                gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.033, 0.0, 0.033);
+            else:
+                gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.5, 0.0, 0.5);
+
             gen.add("auto_exposure_decay", int_t, 0, "AutoExposureDecay", 7, 0, 20)
             gen.add("auto_exposure_thresh", double_t, 0, "AutoExposureThresh", auto_exposure_threshold, 0.0, 1.0)
             gen.add("auto_exposure_target_intensity", double_t, 0, "AutoExposureTargetIntensity", 0.5, 0.0, 1.0)
-            gen.add("exposure_time", double_t, 0, "Exposure", 0.025, 0, 0.5)
+
+            if cfg.ar0234:
+                gen.add("exposure_time", double_t, 0, "Exposure", 0.025, 0, 0.033)
+            else:
+                gen.add("exposure_time", double_t, 0, "Exposure", 0.025, 0, 0.5)
 
             if not cfg.ar0234:
                 gen.add("auto_white_balance", bool_t, 0, "AutoWhiteBalance", True)
@@ -188,11 +214,11 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             gen.add("enable_aux_controls", bool_t, 0, "AuxSensorControls", False)
             gen.add("aux_gain", double_t, 0, "AuxSensorGain", 1.0, 1.0, 8.0)
             gen.add("aux_auto_exposure", bool_t, 0, "AuxAutoExposure", True)
-            gen.add("aux_auto_exposure_max_time", double_t, 0, "AuxAutoExposureMaxTime", 0.5, 0.0, 0.5);
+            gen.add("aux_auto_exposure_max_time", double_t, 0, "AuxAutoExposureMaxTime", 0.033, 0.0, 0.033);
             gen.add("aux_auto_exposure_decay", int_t, 0, "AuxAutoExposureDecay", 7, 0, 20)
             gen.add("aux_auto_exposure_thresh", double_t, 0, "AuxAutoExposureThresh", auto_exposure_threshold, 0.0, 1.0)
             gen.add("aux_auto_exposure_target_intensity", double_t, 0, "AuxAutoExposureTargetIntensity", 0.5, 0.0, 1.0)
-            gen.add("aux_exposure_time", double_t, 0, "AuxExposure", 0.025, 0, 0.5)
+            gen.add("aux_exposure_time", double_t, 0, "AuxExposure", 0.025, 0, 0.033)
             gen.add("aux_roi_auto_exposure", bool_t, 0, "AuxRoiAutoExposure", False)
             gen.add("aux_roi_auto_exposure_x", int_t, 0, "AuxRoiAutoExposureX", 0, 0, 1920)
             gen.add("aux_roi_auto_exposure_y", int_t, 0, "AuxRoiAutoExposureY", 0, 0, 1188)
@@ -217,17 +243,23 @@ for feature_name, feature in SupportedFeatures.__members__.items():
 
         gen.add("network_time_sync", bool_t, 0, "NetworkTimeSynchronization", True);
 
-        if cfg.name.find('sgm_AR0234') != -1:
+        if cfg.ptp:
             gen.add("ptp_time_sync", bool_t, 0, "PTPTimeSynchronization", False);
             trigger_source_enum = gen.enum([ gen.const("internal", int_t, 0, ""),
-                                            gen.const("ptp", int_t, 3, "")],
-                                            "Trigger sources");
+                                             gen.const("ptp", int_t, 3, "")],
+                                             "Trigger sources");
             gen.add("trigger_source", int_t, 0, "Trigger Source", 0, edit_method=trigger_source_enum)
+        #endif
 
-            gen.add("detail_disparity_profile", bool_t, 0, "DetailDisparityProfile", False);
+        if cfg.ar0234:
+            if cfg.sgm:
+                gen.add("detail_disparity_profile", bool_t, 0, "DetailDisparityProfile", False);
+
             gen.add("high_contrast_profile", bool_t, 0, "HighContrastProfile", False);
             gen.add("show_roi_profile", bool_t, 0, "ShowRoiProfile", False);
-            gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
+            if cfg.aux:
+                gen.add("full_res_aux_profile", bool_t, 0, "FullResAuxProfile", False);
+            #endif
 
             if feature == SupportedFeatures.GROUND_SURFACE:
                 gen.add("ground_surface_profile", bool_t, 0, "GroundSurfaceProfile", False);
@@ -288,21 +320,23 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             gen.add("magnetometer_range", int_t, 0, "Magnetometer Range", 0, edit_method=m_range_enum);
         #endif
 
-        clipping_enum = gen.enum([ gen.const("None", int_t, 0, "No Border Clip"),
-                                gen.const("Rectangular", int_t, 1, "Rectangular Border Clip"),
-                                gen.const("Circular", int_t, 2, "Circular Border Clip")],
-                                "Available border clipping options")
+        if cfg.sgm or cfg.name.find("sl_bm") != -1:
+            # clipping is a stereo only feature
+            clipping_enum = gen.enum([ gen.const("None", int_t, 0, "No Border Clip"),
+                                       gen.const("Rectangular", int_t, 1, "Rectangular Border Clip"),
+                                       gen.const("Circular", int_t, 2, "Circular Border Clip")],
+                                     "Available border clipping options")
 
-        if "4000" in cfg.name:
-            clipping_max = 400.0
-        else:
-            clipping_max = 200.0
-        #endif
+            if "4000" in cfg.name:
+                clipping_max = 400.0
+            else:
+                clipping_max = 200.0
+            #endif
 
-        gen.add("border_clip_type", int_t, 0, "point cloud border clip type", 0, 0, 2, edit_method=clipping_enum)
-        gen.add("border_clip_value", double_t, 0, "point cloud border clip value", 0.0, 0.0, clipping_max)
+            gen.add("border_clip_type", int_t, 0, "point cloud border clip type", 0, 0, 2, edit_method=clipping_enum)
+            gen.add("border_clip_value", double_t, 0, "point cloud border clip value", 0.0, 0.0, clipping_max)
 
-        gen.add("max_point_cloud_range", double_t, 0, "max point cloud range", 15.0, 0.0, 100.0)
+            gen.add("max_point_cloud_range", double_t, 0, "max point cloud range", 15.0, 0.0, 100.0)
 
         gen.add("origin_from_camera_position_x_m", double_t, 0, "Origin from camera extrinsics transform x value (m)", 0.0, -100.0, 100.0)
         gen.add("origin_from_camera_position_y_m", double_t, 0, "Origin from camera extrinsics transform y value (m)", 0.0, -100.0, 100.0)

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -345,9 +345,34 @@ private:
     std::unordered_map<crl::multisense::DataSource, std::shared_ptr<BufferWrapper<crl::multisense::image::Header>>> image_buffers_;
 
     //
+    // Has a left camera
+
+    bool has_right_camera_ = false;
+
+    //
+    // Has a left camera
+
+    bool has_left_camera_ = false;
+
+    //
     // Has a 3rd aux color camera
 
     bool has_aux_camera_ = false;
+
+    //
+    // Has color camera streams, either color sensors or a color aux
+
+    bool has_color_ = false;
+
+    //
+    // Can support the ground surface detector
+
+    bool can_support_ground_surface_ = false;
+
+    //
+    // Can support the apriltag detector
+
+    bool can_support_apriltag_ = false;
 
     //
     // Diagnostics

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -77,6 +77,7 @@ public:
     void colorizeCallback(const crl::multisense::image::Header& header);
     void groundSurfaceCallback(const crl::multisense::image::Header& header);
     void groundSurfaceSplineCallback(const crl::multisense::ground_surface::Header& header);
+    void apriltagCallback(const crl::multisense::apriltag::Header& header);
 
     void borderClipChanged(const BorderClip &borderClipType, double borderClipValue);
 
@@ -140,6 +141,7 @@ private:
     static constexpr char GROUND_SURFACE_IMAGE_TOPIC[] = "image";
     static constexpr char GROUND_SURFACE_INFO_TOPIC[] = "camera_info";
     static constexpr char GROUND_SURFACE_POINT_SPLINE_TOPIC[] = "spline";
+    static constexpr char APRILTAG_DETECTION_TOPIC[] = "apriltag_detections";
 
 
     //
@@ -169,6 +171,7 @@ private:
     ros::NodeHandle aux_nh_;
     ros::NodeHandle calibration_nh_;
     ros::NodeHandle ground_surface_nh_;
+    ros::NodeHandle apriltag_nh_;
 
     //
     // Image transports
@@ -222,6 +225,7 @@ private:
     ros::Publisher                   aux_rect_cam_info_pub_;
     ros::Publisher                   aux_rgb_rect_cam_info_pub_;
     ros::Publisher                   ground_surface_info_pub_;
+    ros::Publisher                   apriltag_detection_pub_;
 
     ros::Publisher                   luma_point_cloud_pub_;
     ros::Publisher                   color_point_cloud_pub_;

--- a/multisense_ros/include/multisense_ros/camera_utilities.h
+++ b/multisense_ros/include/multisense_ros/camera_utilities.h
@@ -166,14 +166,43 @@ public:
     Eigen::Matrix4d Q() const;
 
     ///
-    /// @brief Translation which transforms points from the right camera frame into the left camera frame
+    /// @brief Translation which transforms points from the rectified left camera frame into the recified right camera
+    /// frame
     ///
     double T() const;
 
     ///
-    /// @brief Translation which transforms points from the aux camera frame into the left camera frame
+    /// @brief Translation which transforms points from the rectified left camera frame into the rectified aux
+    /// camera frame
     ///
-    double aux_T() const;
+    Eigen::Vector3d aux_T() const;
+
+    ///
+    /// @brief Reproject disparity values into 3D
+    ///
+    Eigen::Vector3f reproject(size_t u, size_t v, double d) const;
+
+    ///
+    /// @brief Reproject disparity values into 3D
+    ///
+    Eigen::Vector3f reproject(size_t u,
+                              size_t v,
+                              double d,
+                              const sensor_msgs::CameraInfo &left_camera_info,
+                              const sensor_msgs::CameraInfo &right_camera_info) const;
+
+    ///
+    /// @brief Project points corresponding to disparity measurements in the left rectified image frame into the
+    ///        aux rectified image plane
+    ///
+    Eigen::Vector2f rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point) const;
+
+    ///
+    /// @brief Project points corresponding to disparity measurements in the left rectified image frame into the
+    ///        aux rectified image plane
+    ///
+    Eigen::Vector2f rectifiedAuxProject(const Eigen::Vector3f &left_rectified_point,
+                                        const sensor_msgs::CameraInfo &aux_camera_info) const;
 
     ///
     /// @brief Get the current main stereo pair operating resolution. This resolution applies for both the mono

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -57,6 +57,11 @@
 #include <multisense_ros/ks21_sgm_AR0234Config.h>
 #include <multisense_ros/ks21_sgm_AR0234_ground_surfaceConfig.h>
 #include <multisense_ros/ks21_sgm_AR0234_apriltagConfig.h>
+#include <multisense_ros/remote_head_vpbConfig.h>
+#include <multisense_ros/remote_head_sgm_AR0234Config.h>
+#include <multisense_ros/remote_head_sgm_AR0234_ground_surfaceConfig.h>
+#include <multisense_ros/remote_head_sgm_AR0234_apriltagConfig.h>
+#include <multisense_ros/remote_head_monocam_AR0234Config.h>
 
 #include <multisense_ros/camera_utilities.h>
 #include <multisense_ros/ground_surface_utilities.h>
@@ -92,13 +97,18 @@ private:
     void callback_st21_vga          (multisense_ros::st21_sgm_vga_imuConfig&   config, uint32_t level);
     void callback_mono_cmv2000      (multisense_ros::mono_cmv2000Config&       config, uint32_t level);
     void callback_mono_cmv4000      (multisense_ros::mono_cmv4000Config&       config, uint32_t level);
-    void callback_s27_AR0234        (multisense_ros::s27_sgm_AR0234Config&     config, uint32_t level);
-    void callback_ks21_AR0234       (multisense_ros::ks21_sgm_AR0234Config&    config, uint32_t level);
 
-    void callback_s27_AR0234_ground_surface        (multisense_ros::s27_sgm_AR0234_ground_surfaceConfig&     dyn, uint32_t level);
-    void callback_ks21_AR0234_ground_surface       (multisense_ros::ks21_sgm_AR0234_ground_surfaceConfig&    dyn, uint32_t level);
-    void callback_s27_AR0234_apriltag              (multisense_ros::s27_sgm_AR0234_apriltagConfig&           dyn, uint32_t level);
-    void callback_ks21_AR0234_apriltag             (multisense_ros::ks21_sgm_AR0234_apriltagConfig&          dyn, uint32_t level);
+    void callback_s27_AR0234                            (multisense_ros::s27_sgm_AR0234Config&                    config, uint32_t level);
+    void callback_s27_AR0234_ground_surface             (multisense_ros::s27_sgm_AR0234_ground_surfaceConfig&     config, uint32_t level);
+    void callback_s27_AR0234_apriltag                   (multisense_ros::s27_sgm_AR0234_apriltagConfig&           config, uint32_t level);
+    void callback_ks21_AR0234                           (multisense_ros::ks21_sgm_AR0234Config&                   config, uint32_t level);
+    void callback_ks21_AR0234_ground_surface            (multisense_ros::ks21_sgm_AR0234_ground_surfaceConfig&    config, uint32_t level);
+    void callback_ks21_AR0234_apriltag                  (multisense_ros::ks21_sgm_AR0234_apriltagConfig&          config, uint32_t level);
+    void callback_remote_head_vpb                      (multisense_ros::remote_head_vpbConfig&                       config, uint32_t level);
+    void callback_remote_head_sgm_AR0234               (multisense_ros::remote_head_sgm_AR0234Config&                config, uint32_t level);
+    void callback_remote_head_sgm_AR0234_ground_surface(multisense_ros::remote_head_sgm_AR0234_ground_surfaceConfig& config, uint32_t level);
+    void callback_remote_head_sgm_AR0234_apriltag      (multisense_ros::remote_head_sgm_AR0234_apriltagConfig&       config, uint32_t level);
+    void callback_remote_head_monocam_AR0234           (multisense_ros::remote_head_monocam_AR0234Config&            config, uint32_t level);
 
     //
     // Internal helper functions
@@ -117,9 +127,11 @@ private:
     template<class T> void configureBorderClip(const T& dyn);
     template<class T> void configurePointCloudRange(const T& dyn);
     template<class T> void configurePtp(const T& dyn);
-    template<class T> void configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn);
-    template<class T> void configureStereoProfileWithGroundSurface(crl::multisense::image::Config &cfg, const T& dyn);
-    template<class T> void configureStereoProfileWithApriltag(crl::multisense::image::Config &cfg, const T& dyn);
+    template<class T> void configureStereoProfile(crl::multisense::CameraProfile &profile, const T& dyn);
+    template<class T> void configureGroundSurfaceStereoProfile(crl::multisense::CameraProfile &profile, const T& dyn);
+    template<class T> void configureApriltagStereoProfile(crl::multisense::CameraProfile &profile, const T& dyn);
+    template<class T> void configureFullResAuxStereoProfile(crl::multisense::CameraProfile &profile, const T& dyn);
+    template<class T> void configureDetailDisparityStereoProfile(crl::multisense::CameraProfile &profile, const T& dyn);
     template<class T> void configureExtrinsics(const T& dyn);
     template<class T> void configureGroundSurfaceParams(const T& dyn);
     template<class T> void configureApriltagParams(const T& dyn);
@@ -159,12 +171,18 @@ private:
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::st21_sgm_vga_imuConfig> >   server_st21_vga_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::mono_cmv2000Config> >       server_mono_cmv2000_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::mono_cmv4000Config> >       server_mono_cmv4000_;
-    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::s27_sgm_AR0234Config> >     server_s27_AR0234_;
-    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234Config> >    server_ks21_sgm_AR0234_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::s27_sgm_AR0234Config> >                    server_s27_AR0234_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::s27_sgm_AR0234_ground_surfaceConfig> >     server_s27_AR0234_ground_surface_;
-    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234_ground_surfaceConfig> >    server_ks21_sgm_AR0234_ground_surface_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::s27_sgm_AR0234_apriltagConfig> >           server_s27_AR0234_apriltag_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234Config> >                   server_ks21_sgm_AR0234_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234_ground_surfaceConfig> >    server_ks21_sgm_AR0234_ground_surface_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234_apriltagConfig> >          server_ks21_sgm_AR0234_apriltag_;
+
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::remote_head_vpbConfig> >                       server_remote_head_vpb_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::remote_head_sgm_AR0234Config> >                server_remote_head_sgm_AR0234_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::remote_head_sgm_AR0234_ground_surfaceConfig> > server_remote_head_sgm_AR0234_ground_surface_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::remote_head_sgm_AR0234_apriltagConfig> >       server_remote_head_sgm_AR0234_apriltag_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::remote_head_monocam_AR0234Config> >            server_remote_head_monocam_AR0234_;
 
     //
     // Cached values for supported sub-systems (these may be unavailable on

--- a/multisense_ros/include/multisense_ros/reconfigure.h
+++ b/multisense_ros/include/multisense_ros/reconfigure.h
@@ -53,8 +53,11 @@
 #include <multisense_ros/mono_cmv4000Config.h>
 #include <multisense_ros/s27_sgm_AR0234Config.h>
 #include <multisense_ros/s27_sgm_AR0234_ground_surfaceConfig.h>
+#include <multisense_ros/s27_sgm_AR0234_apriltagConfig.h>
 #include <multisense_ros/ks21_sgm_AR0234Config.h>
 #include <multisense_ros/ks21_sgm_AR0234_ground_surfaceConfig.h>
+#include <multisense_ros/ks21_sgm_AR0234_apriltagConfig.h>
+
 #include <multisense_ros/camera_utilities.h>
 #include <multisense_ros/ground_surface_utilities.h>
 
@@ -94,6 +97,8 @@ private:
 
     void callback_s27_AR0234_ground_surface        (multisense_ros::s27_sgm_AR0234_ground_surfaceConfig&     dyn, uint32_t level);
     void callback_ks21_AR0234_ground_surface       (multisense_ros::ks21_sgm_AR0234_ground_surfaceConfig&    dyn, uint32_t level);
+    void callback_s27_AR0234_apriltag              (multisense_ros::s27_sgm_AR0234_apriltagConfig&           dyn, uint32_t level);
+    void callback_ks21_AR0234_apriltag             (multisense_ros::ks21_sgm_AR0234_apriltagConfig&          dyn, uint32_t level);
 
     //
     // Internal helper functions
@@ -114,8 +119,10 @@ private:
     template<class T> void configurePtp(const T& dyn);
     template<class T> void configureStereoProfile(crl::multisense::image::Config &cfg, const T& dyn);
     template<class T> void configureStereoProfileWithGroundSurface(crl::multisense::image::Config &cfg, const T& dyn);
+    template<class T> void configureStereoProfileWithApriltag(crl::multisense::image::Config &cfg, const T& dyn);
     template<class T> void configureExtrinsics(const T& dyn);
     template<class T> void configureGroundSurfaceParams(const T& dyn);
+    template<class T> void configureApriltagParams(const T& dyn);
 
     //
     // CRL sensor API
@@ -156,6 +163,8 @@ private:
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234Config> >    server_ks21_sgm_AR0234_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::s27_sgm_AR0234_ground_surfaceConfig> >     server_s27_AR0234_ground_surface_;
     std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234_ground_surfaceConfig> >    server_ks21_sgm_AR0234_ground_surface_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::s27_sgm_AR0234_apriltagConfig> >           server_s27_AR0234_apriltag_;
+    std::shared_ptr< dynamic_reconfigure::Server<multisense_ros::ks21_sgm_AR0234_apriltagConfig> >          server_ks21_sgm_AR0234_apriltag_;
 
     //
     // Cached values for supported sub-systems (these may be unavailable on
@@ -192,7 +201,7 @@ private:
     std::function<void (crl::multisense::system::ExternalCalibration)> extrinsics_callback_;
 
     //
-    // Extrinsics callback to modify pointcloud
+    // Callback to modify spline drawing parameters
 
     std::function<void (ground_surface_utilities::SplineDrawParameters)> spline_draw_parameters_callback_;
 };

--- a/multisense_ros/msg/AprilTagCornerPoint.msg
+++ b/multisense_ros/msg/AprilTagCornerPoint.msg
@@ -1,0 +1,3 @@
+# Apriltag corner point in pixels
+float64 x
+float64 y

--- a/multisense_ros/msg/AprilTagDetection.msg
+++ b/multisense_ros/msg/AprilTagDetection.msg
@@ -1,5 +1,5 @@
 # The family of the tag
-uint64 family
+string family
 
 # The ID of the tag
 uint32 id

--- a/multisense_ros/msg/AprilTagDetection.msg
+++ b/multisense_ros/msg/AprilTagDetection.msg
@@ -12,10 +12,10 @@ uint8 hamming
 # Higher is better. Only useful for small tags
 float32 decisionMargin
 
-# The 3x3 homography matrix describing the projection from an
-# "ideal" tag (with corners at (-1,1), (1,1), (1,-1), and (-1,
-# -1)) to pixels in the image
-std_msgs/Float64MultiArray tagToImageHomography
+# The 3x3 homography matrix (in row-major order) describing the projection
+# from an "ideal" tag (with corners at (-1,1), (1,1), (1,-1), and (-1,-1))
+# to pixels in the image
+float64[9] tagToImageHomography
 
 # The 2D position of the origin of the tag in the image
 float64[2] center

--- a/multisense_ros/msg/AprilTagDetection.msg
+++ b/multisense_ros/msg/AprilTagDetection.msg
@@ -1,0 +1,28 @@
+# The family of the tag
+uint64 family
+
+# The ID of the tag
+uint32 id
+
+# The hamming distance between the detection and the real code
+uint8 hamming
+
+# The quality/confidence of the binary decoding process
+# average difference between intensity of data bit vs decision thresh.
+# Higher is better. Only useful for small tags
+float32 decisionMargin
+
+# The 3x3 homography matrix describing the projection from an
+# "ideal" tag (with corners at (-1,1), (1,1), (1,-1), and (-1,
+# -1)) to pixels in the image
+std_msgs/Float64MultiArray tagToImageHomography
+
+# The 2D position of the origin of the tag in the image
+float64[2] center
+
+# The 4 tag corner pixel locations in the order:
+# point 0: [-squareLength / 2, squareLength / 2]
+# point 1: [ squareLength / 2, squareLength / 2]
+# point 2: [ squareLength / 2, -squareLength / 2]
+# point 3: [-squareLength / 2, -squareLength / 2]
+AprilTagCornerPoint[4] corners

--- a/multisense_ros/msg/AprilTagDetectionArray.msg
+++ b/multisense_ros/msg/AprilTagDetectionArray.msg
@@ -1,10 +1,10 @@
 std_msgs/Header header
 
-# The frame ID of the image that the apriltags were detected on
-int64 frameId
-
 # The frame timestamp (nanoseconds) of the image that the apriltags were detected on
 int64 timestamp
+
+# The image source that the apriltags were detected on
+string imageSource
 
 # Success flag to indicate whether for the apriltag algorithm ran successfully
 uint8 success

--- a/multisense_ros/msg/AprilTagDetectionArray.msg
+++ b/multisense_ros/msg/AprilTagDetectionArray.msg
@@ -1,0 +1,16 @@
+std_msgs/Header header
+
+# The frame ID of the image that the apriltags were detected on
+int64 frameId
+
+# The frame timestamp (nanoseconds) of the image that the apriltags were detected on
+int64 timestamp
+
+# Success flag to indicate whether for the apriltag algorithm ran successfully
+uint8 success
+
+# The number of apriltags that were detected
+uint32 numDetections
+
+# The collection of apriltag detections
+AprilTagDetection[] detections

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -2117,10 +2117,15 @@ void Camera::apriltagCallback(const apriltag::Header& header)
         std::cout << "\tdecisionMargin: " << d.decisionMargin << std::endl;
 
         std::cout << "\ttagToImageHomography: " << std::endl;
-        for (unsigned int i = 0; i < 3; i++)
-            std::cout << "\t\t" << d.tagToImageHomography[i][0] << " "
-                      << d.tagToImageHomography[i][1] << " "
-                      << d.tagToImageHomography[i][2] << std::endl;
+        for (unsigned int col = 0; col < 3; col++)
+        {
+            std::cout << "\t\t";
+            for (unsigned int row = 0; row < 3; row++)
+            {
+                std::cout << d.tagToImageHomography[row][col] << " ";
+            }
+            std::cout << std::endl;
+        }
 
         std::cout << "\tcenter: " << std::endl;
         for (unsigned int i = 0; i < 2; i++)
@@ -2134,7 +2139,7 @@ void Camera::apriltagCallback(const apriltag::Header& header)
     // Publish ROS message
     AprilTagDetectionArray tag_detection_array;
 
-    // TODO(drobinson): Simplify this
+    // TODO(drobinson): Simplify this conversion
     const time_t TICKS_PER_US   = 1000ll;
     int64_t microseconds = header.timestamp / TICKS_PER_US;
     int64_t seconds = (microseconds / 1000000ll);
@@ -2159,27 +2164,11 @@ void Camera::apriltagCallback(const apriltag::Header& header)
         tag_detection.decisionMargin = d.decisionMargin;
 
         // Send tagToImageHomography array
+        for (unsigned int col = 0; col < 3; col++)
         {
-            std_msgs::MultiArrayDimension height;
-            height.label = "height";
-            height.size = 3;
-            height.stride = 9;
-            tag_detection.tagToImageHomography.layout.dim.push_back(height);
-
-            std_msgs::MultiArrayDimension width;
-            width.label = "width";
-            width.size = 3;
-            width.stride = 3;
-            tag_detection.tagToImageHomography.layout.dim.push_back(width);
-
-            tag_detection.tagToImageHomography.layout.data_offset = 0;
-
-            for (unsigned int i = 0; i < 3; i++)
+            for (unsigned int row = 0; row < 3; row++)
             {
-                for (unsigned int j = 0; j < 3; j++)
-                {
-                    tag_detection.tagToImageHomography.data.push_back(d.tagToImageHomography[i][j]);
-                }
+                tag_detection.tagToImageHomography[row + col * 3] = d.tagToImageHomography[row][col];
             }
         }
 

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -2124,7 +2124,7 @@ void Camera::apriltagCallback(const apriltag::Header& header)
     tag_detection_array.header.seq = static_cast<uint32_t>(header.frameId);
     tag_detection_array.header.stamp = ros_time;
     tag_detection_array.header.frame_id = frame_id_rectified_left_;
-    tag_detection_array.frameId = header.frameId;
+    tag_detection_array.imageSource = header.imageSource;
     tag_detection_array.timestamp = header.timestamp;
     tag_detection_array.success = header.success;
     tag_detection_array.numDetections = header.numDetections;

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -2096,15 +2096,13 @@ void Camera::groundSurfaceSplineCallback(const ground_surface::Header& header)
 
 void Camera::apriltagCallback(const apriltag::Header& header)
 {
+    // Convert camera timestamp to ROS timestamp
+    int64_t seconds = std::floor(header.timestamp / 1e9);
+    int64_t nanoseconds = header.timestamp - seconds * 1e9;
+    const ros::Time ros_time(static_cast<uint32_t>(seconds), static_cast<uint32_t>(nanoseconds));
+
     // Publish Apriltags as ROS message
     AprilTagDetectionArray tag_detection_array;
-
-    // TODO(drobinson): Simplify this conversion
-    const time_t TICKS_PER_US = 1000ll;
-    int64_t microseconds = header.timestamp / TICKS_PER_US;
-    int64_t seconds = (microseconds / 1000000ll);
-    microseconds -= (seconds * 1000000ll);
-    const ros::Time ros_time(static_cast<uint32_t>(seconds), 1000 * static_cast<uint32_t>(microseconds));
 
     tag_detection_array.header.seq = static_cast<uint32_t>(header.frameId);
     tag_detection_array.header.stamp = ros_time;

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -352,8 +352,41 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
     //
     // S27/S30 cameras have a 3rd aux color camera and no left color camera
 
+    has_left_camera_ = system::DeviceInfo::HARDWARE_REV_MULTISENSE_SL == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_M == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7S == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S21 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7AR == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_STEREO == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_MONOCAM == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MONO == device_info_.hardwareRevision;
+
+    has_right_camera_ = system::DeviceInfo::HARDWARE_REV_MULTISENSE_SL == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7S == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S21 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7AR == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21 == device_info_.hardwareRevision ||
+                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_STEREO == device_info_.hardwareRevision;
+
     has_aux_camera_ = system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27 == device_info_.hardwareRevision ||
                       system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30 == device_info_.hardwareRevision;
+
+    has_color_ = has_aux_camera_ ||
+                 system::DeviceInfo::HARDWARE_REV_MULTISENSE_M == device_info_.hardwareRevision ||
+                 system::DeviceInfo::IMAGER_TYPE_CMV2000_COLOR == device_info_.imagerType ||
+                 system::DeviceInfo::IMAGER_TYPE_CMV4000_COLOR == device_info_.imagerType ||
+                 system::DeviceInfo::IMAGER_TYPE_AR0239_COLOR == device_info_.imagerType;
+
 
     //
     // Topics published for all device types
@@ -373,12 +406,12 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
         return;
     }
 
-    const bool ground_surface_supported =
+    const bool can_support_ground_surface_ =
         std::any_of(device_modes.begin(), device_modes.end(), [](const auto &mode) {
             return (mode.supportedDataSources & Source_Ground_Surface_Spline_Data) &&
                    (mode.supportedDataSources & Source_Ground_Surface_Class_Image); });
 
-    if (ground_surface_supported) {
+    if (can_support_ground_surface_) {
         ground_surface_cam_pub_ = ground_surface_transport_.advertise(GROUND_SURFACE_IMAGE_TOPIC, 5,
                                 std::bind(&Camera::connectStream, this, Source_Ground_Surface_Class_Image),
                                 std::bind(&Camera::disconnectStream, this, Source_Ground_Surface_Class_Image));
@@ -388,20 +421,19 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
         ground_surface_spline_pub_ = ground_surface_nh_.advertise<sensor_msgs::PointCloud2>(GROUND_SURFACE_POINT_SPLINE_TOPIC, 5, true);
     }
 
-    const bool apriltag_supported =
+    const bool can_support_apriltag_ =
     std::any_of(device_modes.begin(), device_modes.end(), [](const auto &mode) {
         return mode.supportedDataSources & Source_AprilTag_Detections; });
 
-    if (apriltag_supported) {
+    if (can_support_apriltag_) {
         apriltag_detection_pub_ = apriltag_nh_.advertise<AprilTagDetectionArray>(APRILTAG_DETECTION_TOPIC, 5,
                                   std::bind(&Camera::connectStream, this, Source_AprilTag_Detections),
                                   std::bind(&Camera::disconnectStream, this, Source_AprilTag_Detections));
     }
 
-    //
-    // Create topic publishers (TODO: color topics should not be advertised if the device can't support it)
-
     if (system::DeviceInfo::HARDWARE_REV_BCAM == device_info_.hardwareRevision) {
+
+        // bcam has unique topics compared to all other S* variants
 
         left_mono_cam_pub_  = left_mono_transport_.advertise(MONO_TOPIC, 5,
                               std::bind(&Camera::connectStream, this, Source_Luma_Left),
@@ -419,156 +451,160 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
         left_rgb_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(COLOR_CAMERA_INFO_TOPIC, 1, true);
         left_rgb_rect_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(RECT_COLOR_CAMERA_INFO_TOPIC, 1, true);
 
+    } else {
 
-    } else if (system::DeviceInfo::HARDWARE_REV_MULTISENSE_M == device_info_.hardwareRevision) {
+        // all other MultiSense-S* variations
 
-        // monocular variation
+        if (has_left_camera_) {
 
-        left_mono_cam_pub_  = left_mono_transport_.advertise(MONO_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Left),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Left));
-        left_rect_cam_pub_  = left_rect_transport_.advertiseCamera(RECT_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left));
-        left_rgb_cam_pub_   = left_rgb_transport_.advertise(COLOR_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Left | Source_Chroma_Left),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Left | Source_Chroma_Left));
-        left_rgb_rect_cam_pub_ = left_rgb_rect_transport_.advertiseCamera(RECT_COLOR_TOPIC, 5,
-                                 std::bind(&Camera::connectStream, this, Source_Luma_Left | Source_Chroma_Left),
-                                 std::bind(&Camera::disconnectStream, this, Source_Luma_Left | Source_Chroma_Left));
+            left_mono_cam_pub_  = left_mono_transport_.advertise(MONO_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Left),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Left));
 
-        left_mono_cam_info_pub_     = left_nh_.advertise<sensor_msgs::CameraInfo>(MONO_CAMERA_INFO_TOPIC, 1, true);
-        left_rect_cam_info_pub_     = left_nh_.advertise<sensor_msgs::CameraInfo>(RECT_CAMERA_INFO_TOPIC, 1, true);
-        left_rgb_cam_info_pub_      = left_nh_.advertise<sensor_msgs::CameraInfo>(COLOR_CAMERA_INFO_TOPIC, 1, true);
-        left_rgb_rect_cam_info_pub_ = left_nh_.advertise<sensor_msgs::CameraInfo>(RECT_COLOR_CAMERA_INFO_TOPIC, 1, true);
+            left_mono_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(MONO_CAMERA_INFO_TOPIC, 1, true);
 
-    } else {  // all other MultiSense-S* variations
+            left_rect_cam_pub_  = left_rect_transport_.advertiseCamera(RECT_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left));
 
+            left_rect_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(RECT_CAMERA_INFO_TOPIC, 1, true);
+        }
 
-        left_mono_cam_pub_  = left_mono_transport_.advertise(MONO_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Left),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Left));
-        right_mono_cam_pub_ = right_mono_transport_.advertise(MONO_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Right),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Right));
-        left_rect_cam_pub_  = left_rect_transport_.advertiseCamera(RECT_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left));
-        right_rect_cam_pub_ = right_rect_transport_.advertiseCamera(RECT_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Right),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Right));
-        depth_cam_pub_      = depth_transport_.advertise(DEPTH_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Disparity),
-                              std::bind(&Camera::disconnectStream, this, Source_Disparity));
-        ni_depth_cam_pub_   = ni_depth_transport_.advertise(OPENNI_DEPTH_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Disparity),
-                              std::bind(&Camera::disconnectStream, this, Source_Disparity));
+        if (has_right_camera_) {
 
-        if (system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21 != device_info_.hardwareRevision) {
+            right_mono_cam_pub_ = right_mono_transport_.advertise(MONO_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Right),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Right));
 
+            right_mono_cam_info_pub_ = right_nh_.advertise<sensor_msgs::CameraInfo>(MONO_CAMERA_INFO_TOPIC, 1, true);
+
+            right_rect_cam_pub_ = right_rect_transport_.advertiseCamera(RECT_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Right),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Right));
+
+            right_rect_cam_info_pub_ = right_nh_.advertise<sensor_msgs::CameraInfo>(RECT_CAMERA_INFO_TOPIC, 1, true);
+        }
+
+        // only publish for stereo cameras
+        if (has_left_camera_ && has_right_camera_) {
+
+            // run the stereo topics if left and right cameras both exist
+
+            depth_cam_pub_      = depth_transport_.advertise(DEPTH_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Disparity),
+                                  std::bind(&Camera::disconnectStream, this, Source_Disparity));
+
+            ni_depth_cam_pub_   = ni_depth_transport_.advertise(OPENNI_DEPTH_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Disparity),
+                                  std::bind(&Camera::disconnectStream, this, Source_Disparity));
+
+            depth_cam_info_pub_ = device_nh_.advertise<sensor_msgs::CameraInfo>(DEPTH_CAMERA_INFO_TOPIC, 1, true);
+
+            luma_point_cloud_pub_ = device_nh_.advertise<sensor_msgs::PointCloud2>(POINTCLOUD_TOPIC, 5,
+                              std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left | Source_Disparity),
+                              std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left | Source_Disparity));
+
+            luma_organized_point_cloud_pub_ = device_nh_.advertise<sensor_msgs::PointCloud2>(ORGANIZED_POINTCLOUD_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left | Source_Disparity),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left | Source_Disparity));
+
+            raw_cam_data_pub_   = calibration_nh_.advertise<multisense_ros::RawCamData>(RAW_CAM_DATA_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left | Source_Disparity),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left | Source_Disparity));
+
+            left_disparity_pub_ = disparity_left_transport_.advertise(DISPARITY_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Disparity),
+                                  std::bind(&Camera::disconnectStream, this, Source_Disparity));
+
+            left_disp_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(DISPARITY_CAMERA_INFO_TOPIC, 1, true);
+
+            left_stereo_disparity_pub_ = left_nh_.advertise<stereo_msgs::DisparityImage>(DISPARITY_IMAGE_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Disparity),
+                                  std::bind(&Camera::disconnectStream, this, Source_Disparity));
+
+            if (version_info_.sensorFirmwareVersion >= 0x0300) {
+
+                right_disparity_pub_ = disparity_right_transport_.advertise(DISPARITY_TOPIC, 5,
+                                       std::bind(&Camera::connectStream, this, Source_Disparity_Right),
+                                       std::bind(&Camera::disconnectStream, this, Source_Disparity_Right));
+
+                right_disp_cam_info_pub_  = right_nh_.advertise<sensor_msgs::CameraInfo>(DISPARITY_CAMERA_INFO_TOPIC, 1, true);
+
+                right_stereo_disparity_pub_ = right_nh_.advertise<stereo_msgs::DisparityImage>(DISPARITY_IMAGE_TOPIC, 5,
+                                      std::bind(&Camera::connectStream, this, Source_Disparity_Right),
+                                      std::bind(&Camera::disconnectStream, this, Source_Disparity_Right));
+
+                left_disparity_cost_pub_ = disparity_cost_transport_.advertise(COST_TOPIC, 5,
+                                       std::bind(&Camera::connectStream, this, Source_Disparity_Cost),
+                                       std::bind(&Camera::disconnectStream, this, Source_Disparity_Cost));
+
+                left_cost_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(COST_CAMERA_INFO_TOPIC, 1, true);
+            }
+
+            // publish colorized stereo topics
             if (has_aux_camera_) {
 
-                aux_mono_cam_pub_  = aux_mono_transport_.advertise(MONO_TOPIC, 5,
-                                      std::bind(&Camera::connectStream, this, Source_Luma_Aux),
-                                      std::bind(&Camera::disconnectStream, this, Source_Luma_Aux));
+                const auto point_cloud_color_topics = has_aux_camera_ ? Source_Luma_Rectified_Aux | Source_Chroma_Rectified_Aux :
+                                                                        Source_Luma_Left | Source_Chroma_Left;
 
-                aux_mono_cam_info_pub_  = aux_nh_.advertise<sensor_msgs::CameraInfo>(MONO_CAMERA_INFO_TOPIC, 1, true);
+                color_point_cloud_pub_ = device_nh_.advertise<sensor_msgs::PointCloud2>(COLOR_POINTCLOUD_TOPIC, 5,
+                                      std::bind(&Camera::connectStream, this,
+                                      Source_Disparity | point_cloud_color_topics),
+                                      std::bind(&Camera::disconnectStream, this,
+                                      Source_Disparity | point_cloud_color_topics));
 
-                aux_rgb_cam_pub_  = aux_rgb_transport_.advertise(COLOR_TOPIC, 5,
-                                      std::bind(&Camera::connectStream, this, Source_Luma_Aux | Source_Chroma_Aux),
-                                      std::bind(&Camera::disconnectStream, this, Source_Luma_Aux | Source_Chroma_Aux));
-
-                aux_rgb_cam_info_pub_  = aux_nh_.advertise<sensor_msgs::CameraInfo>(COLOR_CAMERA_INFO_TOPIC, 1, true);
-
-                aux_rect_cam_pub_ = aux_rect_transport_.advertiseCamera(RECT_TOPIC, 5,
-                                          std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Aux),
-                                          std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Aux));
-
-                aux_rect_cam_info_pub_  = aux_nh_.advertise<sensor_msgs::CameraInfo>(RECT_CAMERA_INFO_TOPIC, 1, true);
-
-                aux_rgb_rect_cam_pub_ = aux_rgb_rect_transport_.advertiseCamera(RECT_COLOR_TOPIC, 5,
-                                          std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Aux | Source_Chroma_Rectified_Aux),
-                                          std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Aux | Source_Chroma_Rectified_Aux));
-
-                aux_rgb_rect_cam_info_pub_  = aux_nh_.advertise<sensor_msgs::CameraInfo>(RECT_COLOR_CAMERA_INFO_TOPIC, 1, true);
-            }
-            else {
-
-                left_rgb_cam_pub_   = left_rgb_transport_.advertise(COLOR_TOPIC, 5,
-                                      std::bind(&Camera::connectStream, this, Source_Luma_Left | Source_Chroma_Left),
-                                      std::bind(&Camera::disconnectStream, this, Source_Luma_Left | Source_Chroma_Left));
-
-                left_rgb_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(COLOR_CAMERA_INFO_TOPIC, 1, true);
-                left_rgb_rect_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(RECT_COLOR_CAMERA_INFO_TOPIC, 1, true);
-
-                left_rgb_rect_cam_pub_ = left_rgb_rect_transport_.advertiseCamera(RECT_COLOR_TOPIC, 5,
-                                      std::bind(&Camera::connectStream, this, Source_Luma_Left | Source_Chroma_Left),
-                                      std::bind(&Camera::disconnectStream, this, Source_Luma_Left | Source_Chroma_Left));
+                color_organized_point_cloud_pub_ = device_nh_.advertise<sensor_msgs::PointCloud2>(COLOR_ORGANIZED_POINTCLOUD_TOPIC, 5,
+                                      std::bind(&Camera::connectStream, this,
+                                      Source_Disparity | point_cloud_color_topics),
+                                      std::bind(&Camera::disconnectStream, this,
+                                      Source_Disparity | point_cloud_color_topics));
 
             }
 
-            const auto point_cloud_color_topics = has_aux_camera_ ? Source_Luma_Rectified_Aux | Source_Chroma_Rectified_Aux :
-                                                                   Source_Luma_Left | Source_Chroma_Left;
+        }
 
-            color_point_cloud_pub_ = device_nh_.advertise<sensor_msgs::PointCloud2>(COLOR_POINTCLOUD_TOPIC, 5,
-                                  std::bind(&Camera::connectStream, this,
-                                  Source_Disparity | point_cloud_color_topics),
-                                  std::bind(&Camera::disconnectStream, this,
-                                  Source_Disparity | point_cloud_color_topics));
-            color_organized_point_cloud_pub_ = device_nh_.advertise<sensor_msgs::PointCloud2>(COLOR_ORGANIZED_POINTCLOUD_TOPIC, 5,
-                                  std::bind(&Camera::connectStream, this,
-                                  Source_Disparity | point_cloud_color_topics),
-                                  std::bind(&Camera::disconnectStream, this,
-                                  Source_Disparity | point_cloud_color_topics));
+        // handle color topic publishing if color data exists
+        if (has_aux_camera_) {
+
+            aux_mono_cam_pub_  = aux_mono_transport_.advertise(MONO_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Aux),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Aux));
+
+            aux_mono_cam_info_pub_  = aux_nh_.advertise<sensor_msgs::CameraInfo>(MONO_CAMERA_INFO_TOPIC, 1, true);
+
+            aux_rgb_cam_pub_  = aux_rgb_transport_.advertise(COLOR_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Aux | Source_Chroma_Aux),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Aux | Source_Chroma_Aux));
+
+            aux_rgb_cam_info_pub_  = aux_nh_.advertise<sensor_msgs::CameraInfo>(COLOR_CAMERA_INFO_TOPIC, 1, true);
+
+            aux_rect_cam_pub_ = aux_rect_transport_.advertiseCamera(RECT_TOPIC, 5,
+                                      std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Aux),
+                                      std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Aux));
+
+            aux_rect_cam_info_pub_  = aux_nh_.advertise<sensor_msgs::CameraInfo>(RECT_CAMERA_INFO_TOPIC, 1, true);
+
+            aux_rgb_rect_cam_pub_ = aux_rgb_rect_transport_.advertiseCamera(RECT_COLOR_TOPIC, 5,
+                                      std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Aux | Source_Chroma_Rectified_Aux),
+                                      std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Aux | Source_Chroma_Rectified_Aux));
+
+            aux_rgb_rect_cam_info_pub_  = aux_nh_.advertise<sensor_msgs::CameraInfo>(RECT_COLOR_CAMERA_INFO_TOPIC, 1, true);
+
+        } else if (has_color_ && !has_aux_camera_) { // !has_aux_camera_ is redundant, but leaving to prevent confusion over edge cases
+
+            left_rgb_cam_pub_   = left_rgb_transport_.advertise(COLOR_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Left | Source_Chroma_Left),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Left | Source_Chroma_Left));
+
+            left_rgb_rect_cam_pub_ = left_rgb_rect_transport_.advertiseCamera(RECT_COLOR_TOPIC, 5,
+                                  std::bind(&Camera::connectStream, this, Source_Luma_Left | Source_Chroma_Left),
+                                  std::bind(&Camera::disconnectStream, this, Source_Luma_Left | Source_Chroma_Left));
+
+            left_rgb_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(COLOR_CAMERA_INFO_TOPIC, 1, true);
+            left_rgb_rect_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(RECT_COLOR_CAMERA_INFO_TOPIC, 1, true);
 
         }
 
-        luma_point_cloud_pub_ = device_nh_.advertise<sensor_msgs::PointCloud2>(POINTCLOUD_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left | Source_Disparity),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left | Source_Disparity));
-
-        luma_organized_point_cloud_pub_ = device_nh_.advertise<sensor_msgs::PointCloud2>(ORGANIZED_POINTCLOUD_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left | Source_Disparity),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left | Source_Disparity));
-
-        raw_cam_data_pub_   = calibration_nh_.advertise<multisense_ros::RawCamData>(RAW_CAM_DATA_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Luma_Rectified_Left | Source_Disparity),
-                              std::bind(&Camera::disconnectStream, this, Source_Luma_Rectified_Left | Source_Disparity));
-
-        left_disparity_pub_ = disparity_left_transport_.advertise(DISPARITY_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Disparity),
-                              std::bind(&Camera::disconnectStream, this, Source_Disparity));
-
-        left_stereo_disparity_pub_ = left_nh_.advertise<stereo_msgs::DisparityImage>(DISPARITY_IMAGE_TOPIC, 5,
-                              std::bind(&Camera::connectStream, this, Source_Disparity),
-                              std::bind(&Camera::disconnectStream, this, Source_Disparity));
-
-        if (version_info_.sensorFirmwareVersion >= 0x0300) {
-
-            right_disparity_pub_ = disparity_right_transport_.advertise(DISPARITY_TOPIC, 5,
-                                   std::bind(&Camera::connectStream, this, Source_Disparity_Right),
-                                   std::bind(&Camera::disconnectStream, this, Source_Disparity_Right));
-
-            right_stereo_disparity_pub_ = right_nh_.advertise<stereo_msgs::DisparityImage>(DISPARITY_IMAGE_TOPIC, 5,
-                                  std::bind(&Camera::connectStream, this, Source_Disparity_Right),
-                                  std::bind(&Camera::disconnectStream, this, Source_Disparity_Right));
-
-            left_disparity_cost_pub_ = disparity_cost_transport_.advertise(COST_TOPIC, 5,
-                                   std::bind(&Camera::connectStream, this, Source_Disparity_Cost),
-                                   std::bind(&Camera::disconnectStream, this, Source_Disparity_Cost));
-
-            right_disp_cam_info_pub_  = right_nh_.advertise<sensor_msgs::CameraInfo>(DISPARITY_CAMERA_INFO_TOPIC, 1, true);
-            left_cost_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(COST_CAMERA_INFO_TOPIC, 1, true);
-        }
-
-        //
-        // Camera info topic publishers
-        left_mono_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(MONO_CAMERA_INFO_TOPIC, 1, true);
-        right_mono_cam_info_pub_ = right_nh_.advertise<sensor_msgs::CameraInfo>(MONO_CAMERA_INFO_TOPIC, 1, true);
-        left_rect_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(RECT_CAMERA_INFO_TOPIC, 1, true);
-        right_rect_cam_info_pub_ = right_nh_.advertise<sensor_msgs::CameraInfo>(RECT_CAMERA_INFO_TOPIC, 1, true);
-        left_disp_cam_info_pub_  = left_nh_.advertise<sensor_msgs::CameraInfo>(DISPARITY_CAMERA_INFO_TOPIC, 1, true);
-        depth_cam_info_pub_ = device_nh_.advertise<sensor_msgs::CameraInfo>(DEPTH_CAMERA_INFO_TOPIC, 1, true);
     }
 
     //
@@ -627,35 +663,56 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
     // Publish image calibration
 
     image::Calibration image_calibration;
-    status = driver_->getImageCalibration(image_calibration);
-    if (Status_Ok != status) {
-        ROS_ERROR("Camera: failed to query image calibration: %s",
-                  Channel::statusString(status));
-    }
-    else {
+    if (has_left_camera_ || has_right_camera_ || has_aux_camera_)
+    {
+        status = driver_->getImageCalibration(image_calibration);
+        if (Status_Ok != status) {
+            ROS_ERROR("Camera: failed to query image calibration: %s",
+                      Channel::statusString(status));
+        }
+        else {
+            // currently no ROS cameras have only an aux camera
+            // HARDWARE_REV_MULTISENSE_MONOCAM uses the left cal for its calibration
 
-        multisense_ros::RawCamCal cal;
-        const float              *cP;
+            multisense_ros::RawCamCal cal;
+            const float              *cP;
 
-        cP = reinterpret_cast<const float *>(&(image_calibration.left.M[0][0]));
-        for(uint32_t i=0; i<9; i++) cal.left_M[i] = cP[i];
-        cP = reinterpret_cast<const float *>(&(image_calibration.left.D[0]));
-        for(uint32_t i=0; i<8; i++) cal.left_D[i] = cP[i];
-        cP = reinterpret_cast<const float *>(&(image_calibration.left.R[0][0]));
-        for(uint32_t i=0; i<9; i++) cal.left_R[i] = cP[i];
-        cP = reinterpret_cast<const float *>(&(image_calibration.left.P[0][0]));
-        for(uint32_t i=0; i<12; i++) cal.left_P[i] = cP[i];
+            cP = reinterpret_cast<const float *>(&(image_calibration.left.M[0][0]));
+            for(uint32_t i=0; i<9; i++) cal.left_M[i] = cP[i];
+            cP = reinterpret_cast<const float *>(&(image_calibration.left.D[0]));
+            for(uint32_t i=0; i<8; i++) cal.left_D[i] = cP[i];
+            cP = reinterpret_cast<const float *>(&(image_calibration.left.R[0][0]));
+            for(uint32_t i=0; i<9; i++) cal.left_R[i] = cP[i];
+            cP = reinterpret_cast<const float *>(&(image_calibration.left.P[0][0]));
+            for(uint32_t i=0; i<12; i++) cal.left_P[i] = cP[i];
 
-        cP = reinterpret_cast<const float *>(&(image_calibration.right.M[0][0]));
-        for(uint32_t i=0; i<9; i++) cal.right_M[i] = cP[i];
-        cP = reinterpret_cast<const float *>(&(image_calibration.right.D[0]));
-        for(uint32_t i=0; i<8; i++) cal.right_D[i] = cP[i];
-        cP = reinterpret_cast<const float *>(&(image_calibration.right.R[0][0]));
-        for(uint32_t i=0; i<9; i++) cal.right_R[i] = cP[i];
-        cP = reinterpret_cast<const float *>(&(image_calibration.right.P[0][0]));
-        for(uint32_t i=0; i<12; i++) cal.right_P[i] = cP[i];
+            if (not has_right_camera_) {
 
-        raw_cam_cal_pub_.publish(cal);
+                // publish the left calibration twice if there is no right camera
+                cP = reinterpret_cast<const float *>(&(image_calibration.left.M[0][0]));
+                for(uint32_t i=0; i<9; i++) cal.right_M[i] = cP[i];
+                cP = reinterpret_cast<const float *>(&(image_calibration.left.D[0]));
+                for(uint32_t i=0; i<8; i++) cal.right_D[i] = cP[i];
+                cP = reinterpret_cast<const float *>(&(image_calibration.left.R[0][0]));
+                for(uint32_t i=0; i<9; i++) cal.right_R[i] = cP[i];
+                cP = reinterpret_cast<const float *>(&(image_calibration.left.P[0][0]));
+                for(uint32_t i=0; i<12; i++) cal.right_P[i] = cP[i];
+
+            } else {
+
+                cP = reinterpret_cast<const float *>(&(image_calibration.right.M[0][0]));
+                for(uint32_t i=0; i<9; i++) cal.right_M[i] = cP[i];
+                cP = reinterpret_cast<const float *>(&(image_calibration.right.D[0]));
+                for(uint32_t i=0; i<8; i++) cal.right_D[i] = cP[i];
+                cP = reinterpret_cast<const float *>(&(image_calibration.right.R[0][0]));
+                for(uint32_t i=0; i<9; i++) cal.right_R[i] = cP[i];
+                cP = reinterpret_cast<const float *>(&(image_calibration.right.P[0][0]));
+                for(uint32_t i=0; i<12; i++) cal.right_P[i] = cP[i];
+
+            }
+
+            raw_cam_cal_pub_.publish(cal);
+        }
     }
 
     stereo_calibration_manager_ = std::make_shared<StereoCalibrationManger>(image_config, image_calibration, device_info_);
@@ -736,17 +793,37 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
         driver_->addIsolatedCallback(monoCB, Source_Luma_Left, this);
         driver_->addIsolatedCallback(jpegCB, Source_Jpeg_Left, this);
 
+    } else if (system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_VPB == device_info_.hardwareRevision) {
+        // no incoming image data from vpb
+    } else if (system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_MONOCAM == device_info_.hardwareRevision) {
+
+        driver_->addIsolatedCallback(monoCB,  Source_Luma_Left, this);
+        driver_->addIsolatedCallback(rectCB,  Source_Luma_Rectified_Left, this);
+
     } else {
 
-        driver_->addIsolatedCallback(colorizeCB, Source_Luma_Rectified_Aux | Source_Chroma_Rectified_Aux | Source_Luma_Aux |
-                                                 Source_Luma_Left | Source_Chroma_Left | Source_Luma_Rectified_Left, this);
-        driver_->addIsolatedCallback(monoCB,  Source_Luma_Left | Source_Luma_Right | Source_Luma_Aux, this);
-        driver_->addIsolatedCallback(rectCB,  Source_Luma_Rectified_Left | Source_Luma_Rectified_Right | Source_Luma_Rectified_Aux, this);
-        driver_->addIsolatedCallback(depthCB, Source_Disparity, this);
-        driver_->addIsolatedCallback(pointCB, Source_Disparity, this);
-        driver_->addIsolatedCallback(rawCB,   Source_Disparity | Source_Luma_Rectified_Left, this);
-        driver_->addIsolatedCallback(colorCB, Source_Chroma_Left | Source_Chroma_Rectified_Aux | Source_Chroma_Aux, this);
-        driver_->addIsolatedCallback(dispCB,  Source_Disparity | Source_Disparity_Right | Source_Disparity_Cost, this);
+        if (has_left_camera_ || has_right_camera_ || has_aux_camera_) {
+            driver_->addIsolatedCallback(monoCB,  Source_Luma_Left | Source_Luma_Right | Source_Luma_Aux, this);
+            driver_->addIsolatedCallback(rectCB,  Source_Luma_Rectified_Left | Source_Luma_Rectified_Right | Source_Luma_Rectified_Aux, this);
+        }
+
+        if (has_color_) {
+            if (has_aux_camera_) {
+                driver_->addIsolatedCallback(colorizeCB, Source_Luma_Rectified_Aux | Source_Chroma_Rectified_Aux | Source_Luma_Aux |
+                                                         Source_Luma_Left | Source_Luma_Rectified_Left, this);
+                driver_->addIsolatedCallback(colorCB, Source_Chroma_Rectified_Aux | Source_Chroma_Aux, this);
+            } else {
+                driver_->addIsolatedCallback(colorizeCB, Source_Luma_Left | Source_Chroma_Left | Source_Luma_Rectified_Left, this);
+                driver_->addIsolatedCallback(colorCB, Source_Chroma_Left, this);
+            }
+        }
+
+        if (has_left_camera_ && has_right_camera_) {
+            driver_->addIsolatedCallback(depthCB, Source_Disparity, this);
+            driver_->addIsolatedCallback(pointCB, Source_Disparity, this);
+            driver_->addIsolatedCallback(rawCB,   Source_Disparity | Source_Luma_Rectified_Left, this);
+            driver_->addIsolatedCallback(dispCB,  Source_Disparity | Source_Disparity_Right | Source_Disparity_Cost, this);
+        }
     }
 
     //
@@ -757,12 +834,12 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
     //
     // Add algorithm callbacks
 
-    if (ground_surface_supported) {
+    if (can_support_ground_surface_) {
         driver_->addIsolatedCallback(groundSurfaceCB, Source_Ground_Surface_Class_Image, this);
         driver_->addIsolatedCallback(groundSurfaceSplineCB, this);
     }
 
-    if (apriltag_supported) {
+    if (can_support_apriltag_) {
         driver_->addIsolatedCallback(apriltagCB, this);
     }
 
@@ -793,19 +870,34 @@ Camera::~Camera()
 
     } else {
 
-        driver_->removeIsolatedCallback(colorizeCB);
-        driver_->removeIsolatedCallback(monoCB);
-        driver_->removeIsolatedCallback(rectCB);
-        driver_->removeIsolatedCallback(depthCB);
-        driver_->removeIsolatedCallback(pointCB);
-        driver_->removeIsolatedCallback(rawCB);
-        driver_->removeIsolatedCallback(colorCB);
-        driver_->removeIsolatedCallback(dispCB);
+        if (has_left_camera_ || has_right_camera_ || has_aux_camera_) {
+            driver_->removeIsolatedCallback(monoCB);
+            driver_->removeIsolatedCallback(rectCB);
+        }
+
+        if (has_color_) {
+            driver_->removeIsolatedCallback(colorizeCB);
+            driver_->removeIsolatedCallback(colorCB);
+        }
+
+        if (has_left_camera_ && has_right_camera_) {
+            driver_->removeIsolatedCallback(depthCB);
+            driver_->removeIsolatedCallback(pointCB);
+            driver_->removeIsolatedCallback(rawCB);
+            driver_->removeIsolatedCallback(dispCB);
+        }
     }
 
-    driver_->removeIsolatedCallback(groundSurfaceCB);
-    driver_->removeIsolatedCallback(groundSurfaceSplineCB);
-    driver_->removeIsolatedCallback(apriltagCB);
+    if (can_support_ground_surface_)
+    {
+        driver_->removeIsolatedCallback(groundSurfaceCB);
+        driver_->removeIsolatedCallback(groundSurfaceSplineCB);
+    }
+
+    if (can_support_apriltag_)
+    {
+        driver_->removeIsolatedCallback(apriltagCB);
+    }
 }
 
 void Camera::borderClipChanged(const BorderClip &borderClipType, double borderClipValue)
@@ -2244,36 +2336,30 @@ void Camera::publishAllCameraInfo()
 
     } else {  // all other MultiSense-S* variations
 
-        if (system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21 != device_info_.hardwareRevision) {
+        if (has_left_camera_) {
+            left_mono_cam_info_pub_.publish(left_camera_info);
+            left_rect_cam_info_pub_.publish(left_rectified_camera_info);
+        }
 
-            if (has_aux_camera_) {
+        if (has_right_camera_) {
+            right_mono_cam_info_pub_.publish(right_camera_info);
+            right_rect_cam_info_pub_.publish(right_rectified_camera_info);
+        }
 
-                aux_mono_cam_info_pub_.publish(left_camera_info);
-                aux_rgb_cam_info_pub_.publish(left_camera_info);
-                aux_rect_cam_info_pub_.publish(left_rectified_camera_info);
-                aux_rgb_rect_cam_info_pub_.publish(left_rectified_camera_info);
+        // only publish for stereo cameras
+        if (has_left_camera_ && has_right_camera_) {
 
-            } else {
+            left_disp_cam_info_pub_.publish(left_rectified_camera_info);
+            depth_cam_info_pub_.publish(left_rectified_camera_info);
 
-                left_rgb_cam_info_pub_.publish(left_camera_info);
-                left_rgb_rect_cam_info_pub_.publish(left_rectified_camera_info);
+            if (version_info_.sensorFirmwareVersion >= 0x0300) {
 
+                right_disp_cam_info_pub_.publish(right_rectified_camera_info);
+                left_cost_cam_info_pub_.publish(left_rectified_camera_info);
             }
         }
 
-        if (version_info_.sensorFirmwareVersion >= 0x0300) {
-
-            right_disp_cam_info_pub_.publish(right_rectified_camera_info);
-            left_cost_cam_info_pub_.publish(left_rectified_camera_info);
-        }
-
-        left_mono_cam_info_pub_.publish(left_camera_info);
-        left_rect_cam_info_pub_.publish(left_rectified_camera_info);
-        right_mono_cam_info_pub_.publish(right_camera_info);
-        right_rect_cam_info_pub_.publish(right_rectified_camera_info);
-        left_disp_cam_info_pub_.publish(left_rectified_camera_info);
-        depth_cam_info_pub_.publish(left_rectified_camera_info);
-
+        // handle color topic publishing if color data exists
         if (has_aux_camera_) {
 
             //
@@ -2288,6 +2374,12 @@ void Camera::publishAllCameraInfo()
 
             aux_rgb_cam_info_pub_.publish(stereo_calibration_manager_->auxCameraInfo(frame_id_aux_, stamp, auxResolution));
             aux_rgb_rect_cam_info_pub_.publish(stereo_calibration_manager_->auxCameraInfo(frame_id_rectified_aux_, stamp, stereoResolution));
+
+        } else if (has_color_ && !has_aux_camera_) { // !has_aux_camera_ is redundant, but leaving to prevent confusion over edge cases
+
+            left_rgb_cam_info_pub_.publish(left_camera_info);
+            left_rgb_rect_cam_info_pub_.publish(left_rectified_camera_info);
+
         }
     }
 }

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -116,7 +116,7 @@ void groundSurfaceSplineCB(const ground_surface::Header& header, void* userDataP
 { reinterpret_cast<Camera*>(userDataP)->groundSurfaceSplineCallback(header); }
 
 
-bool isValidReprojectedPoint(const Eigen::Vector3f& pt, double squared_max_range)
+bool isValidReprojectedPoint(const Eigen::Vector3f& pt, float squared_max_range)
 {
     return pt[2] > 0.0f && std::isfinite(pt[2]) && pt.squaredNorm() < squared_max_range;
 }
@@ -195,26 +195,38 @@ bool clipPoint(const BorderClip& borderClipType,
     return true;
 }
 
-cv::Vec3b u_interpolate_color(double u, double v, const cv::Mat &image)
+cv::Vec3b interpolate_color(const Eigen::Vector2f &pixel, const cv::Mat &image)
 {
-    const double width = image.cols;
+    const float width = image.cols;
+    const float height = image.rows;
+
+    const float &u = pixel(0);
+    const float &v = pixel(1);
 
     //
-    // Interpolate in just the u dimension
+    // Implement a basic bileinar interpolation scheme
+    // https://en.wikipedia.org/wiki/Bilinear_interpolation
     //
-    const size_t min_u = static_cast<size_t>(std::min(std::max(std::floor(u), 0.), width - 1.));
-    const size_t max_u = static_cast<size_t>(std::min(std::max(std::ceil(u), 0.), width - 1.));
+    const size_t min_u = static_cast<size_t>(std::min(std::max(std::floor(u), 0.f), width - 1.f));
+    const size_t max_u = static_cast<size_t>(std::min(std::max(std::floor(u) + 1, 0.f), width - 1.f));
+    const size_t min_v = static_cast<size_t>(std::min(std::max(std::floor(v), 0.f), height - 1.f));
+    const size_t max_v = static_cast<size_t>(std::min(std::max(std::floor(v) + 1, 0.f), height - 1.f));
 
-    const cv::Vec3d element0 = image.at<cv::Vec3b>(width * v + min_u);
-    const cv::Vec3d element1 = image.at<cv::Vec3b>(width * v + max_u);
+    const cv::Vec3d element00 = image.at<cv::Vec3b>(width * min_v + min_u);
+    const cv::Vec3d element01 = image.at<cv::Vec3b>(width * min_v + max_u);
+    const cv::Vec3d element10 = image.at<cv::Vec3b>(width * max_v + min_u);
+    const cv::Vec3d element11 = image.at<cv::Vec3b>(width * max_v + max_u);
 
     const size_t delta_u = max_u - min_u;
+    const size_t delta_v = max_u - min_u;
 
     const double u_ratio = delta_u == 0 ? 1. : (static_cast<double>(max_u) - u) / static_cast<double>(delta_u);
+    const double v_ratio = delta_v == 0 ? 1. : (static_cast<double>(max_v) - v) / static_cast<double>(delta_v);
 
-    const cv::Vec3b result = (element0 * u_ratio + element1 * (1. - u_ratio));
+    const cv::Vec3b f_xy0 = element00 * u_ratio + element01 * (1. - u_ratio);
+    const cv::Vec3b f_xy1 = element10 * u_ratio + element11 * (1. - u_ratio);
 
-    return result;
+    return (f_xy0 * v_ratio + f_xy1 * (1. - v_ratio));
 }
 
 } // anonymous
@@ -655,8 +667,10 @@ Camera::Camera(Channel* driver, const std::string& tf_prefix) :
 
     if (has_aux_extrinsics)
     {
+        const Eigen::Vector3d aux_T = stereo_calibration_manager_->aux_T();
+
         tf2::Transform rectified_aux_T_rectified_left{tf2::Matrix3x3::getIdentity(),
-                                                      tf2::Vector3{stereo_calibration_manager_->aux_T(), 0., 0.}};
+                                                      tf2::Vector3{aux_T(0), aux_T(1), aux_T(2)}};
         stamped_transforms[3].header.stamp = ros::Time::now();
         stamped_transforms[3].header.frame_id = frame_id_rectified_left_;
         stamped_transforms[3].child_frame_id = frame_id_rectified_aux_;
@@ -1542,8 +1556,6 @@ void Camera::pointCloudCallback(const image::Header& header)
         color_organized_point_cloud_.row_step = header.width * color_organized_point_cloud_.point_step;
     }
 
-    const Eigen::Matrix4d Q = stereo_calibration_manager_->Q();
-
     const Eigen::Vector3f invalid_point(std::numeric_limits<float>::quiet_NaN(),
                                         std::numeric_limits<float>::quiet_NaN(),
                                         std::numeric_limits<float>::quiet_NaN());
@@ -1598,15 +1610,17 @@ void Camera::pointCloudCallback(const image::Header& header)
         rectified_color = std::move(rect_rgb_image);
     }
 
+    const auto left_camera_info = stereo_calibration_manager_->leftCameraInfo(frame_id_left_, t);
+    const auto right_camera_info = stereo_calibration_manager_->rightCameraInfo(frame_id_right_, t);
+    const auto aux_camera_info = stereo_calibration_manager_->auxCameraInfo(frame_id_rectified_aux_, t,
+                                                                            rectified_color.cols, rectified_color.rows);
+
     //
     // Iterate through our disparity image once populating our pointcloud structures if we plan to publish them
 
     uint32_t packed_color = 0;
 
-    const double squared_max_range = pointcloud_max_range_ * pointcloud_max_range_;
-
-    const double aux_T = has_aux_camera_ ? stereo_calibration_manager_->aux_T() : stereo_calibration_manager_->T();
-    const double T = stereo_calibration_manager_->T();
+    const float squared_max_range = pointcloud_max_range_ * pointcloud_max_range_;
 
     size_t valid_points = 0;
     for (size_t y = 0 ; y < header.height ; ++y)
@@ -1615,17 +1629,17 @@ void Camera::pointCloudCallback(const image::Header& header)
         {
             const size_t index = y * header.width + x;
 
-            double disparity = 0.0f;
+            float disparity = 0.0f;
             switch(header.bitsPerPixel)
             {
                 case 16:
                 {
-                    disparity = static_cast<double>(reinterpret_cast<const uint16_t*>(header.imageDataP)[index]) / 16.0f;
+                    disparity = static_cast<float>(reinterpret_cast<const uint16_t*>(header.imageDataP)[index]) / 16.0f;
                     break;
                 }
                 case 32:
                 {
-                    disparity = static_cast<double>(reinterpret_cast<const float*>(header.imageDataP)[index]);
+                    disparity = static_cast<float>(reinterpret_cast<const float*>(header.imageDataP)[index]);
                     break;
                 }
                 default:
@@ -1635,6 +1649,9 @@ void Camera::pointCloudCallback(const image::Header& header)
                 }
             }
 
+            const Eigen::Vector3f point = stereo_calibration_manager_->reproject(x, y, disparity,
+                                                                                 left_camera_info, right_camera_info);
+
             //
             // We have a valid rectified color image meaning we plan to publish color pointcloud topics. Assemble the
             // color pixel here since it may be needed in our organized pointclouds
@@ -1643,10 +1660,11 @@ void Camera::pointCloudCallback(const image::Header& header)
             {
                 packed_color = 0;
 
-                const double color_d = has_aux_camera_ ? (disparity * aux_T) / T : 0.0;
+                const auto color_pixel = (has_aux_camera_ && disparity != 0.0) ?
+                    interpolate_color(stereo_calibration_manager_->rectifiedAuxProject(point, aux_camera_info),
+                                      rectified_color) :
+                    rectified_color.at<cv::Vec3b>(y, x);
 
-                const auto color_pixel = has_aux_camera_ ? u_interpolate_color(std::max(x - color_d, 0.), y, rectified_color) :
-                                                          rectified_color.at<cv::Vec3b>(y, x);
 
                 packed_color |= color_pixel[2] << 16 | color_pixel[1] << 8 | color_pixel[0];
             }
@@ -1655,7 +1673,7 @@ void Camera::pointCloudCallback(const image::Header& header)
             // If our disparity is 0 pixels our corresponding 3D point is infinite. If we plan to publish organized
             // pointclouds we will need to add a invalid point to our pointcloud(s)
 
-            if (disparity == 0.0f || clipPoint(border_clip_type_, border_clip_value_, header.width, header.height, x, y))
+            if (disparity == 0.0 || clipPoint(border_clip_type_, border_clip_value_, header.width, header.height, x, y))
             {
                 if (pub_organized_pointcloud)
                 {
@@ -1669,12 +1687,6 @@ void Camera::pointCloudCallback(const image::Header& header)
 
                 continue;
             }
-
-            const Eigen::Vector3f point = ((Q * Eigen::Vector4d(static_cast<double>(x),
-                                                                static_cast<double>(y),
-                                                                disparity,
-                                                                1.0)).hnormalized()).cast<float>();
-
 
             const bool valid = isValidReprojectedPoint(point, squared_max_range);
 

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -878,6 +878,7 @@ template<class T> void Reconfigure::configureApriltagParams(const T& dyn)
     crl::multisense::system::ApriltagParams params;
 
     params.family = dyn.apriltag_family;
+    params.max_hamming = dyn.apriltag_max_hamming;
     params.quad_detection_blur_sigma = dyn.apriltag_quad_detection_blur_sigma;
     params.quad_detection_decimate = dyn.apriltag_quad_detection_decimate;
     params.min_border_width = dyn.apriltag_min_border_width;

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -885,7 +885,6 @@ template<class T> void Reconfigure::configureApriltagParams(const T& dyn)
     params.refine_quad_edges = dyn.apriltag_refine_quad_edges;
     params.decode_sharpening = dyn.apriltag_decode_sharpening;
 
-    // Update ground surface params on camera
     Status status = driver_->setApriltagParams(params);
     if (Status_Ok != status) {
             ROS_ERROR("Reconfigure: failed to set apriltag params: %s",

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -743,6 +743,7 @@ template<class T> void Reconfigure::configureStereoProfile(crl::multisense::imag
     profile |= (dyn.high_contrast_profile ? crl::multisense::High_Contrast : profile);
     profile |= (dyn.show_roi_profile ? crl::multisense::Show_ROIs : profile);
     profile |= (dyn.full_res_aux_profile ? crl::multisense::Full_Res_Aux_Cam : profile);
+    profile |= (dyn.apriltag_profile ? crl::multisense::AprilTag : profile);
 
     cfg.setCameraProfile(profile);
 }
@@ -755,6 +756,7 @@ template<class T> void Reconfigure::configureStereoProfileWithGroundSurface(crl:
     profile |= (dyn.show_roi_profile ? crl::multisense::Show_ROIs : profile);
     profile |= (dyn.full_res_aux_profile ? crl::multisense::Full_Res_Aux_Cam : profile);
     profile |= (dyn.ground_surface_profile ? crl::multisense::Ground_Surface : profile);
+    profile |= (dyn.apriltag_profile ? crl::multisense::AprilTag : profile);
 
     cfg.setCameraProfile(profile);
 }

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -55,20 +55,41 @@ int main(int argc, char** argvPP)
     std::string sensor_ip;
     std::string tf_prefix;
     int         sensor_mtu;
+    int         head_id;
 
 
     nh_private_.param<std::string>("sensor_ip", sensor_ip, "10.66.171.21");
     nh_private_.param<std::string>("tf_prefix", tf_prefix, "multisense");
     nh_private_.param<int>("sensor_mtu", sensor_mtu, 7200);
+    nh_private_.param<int>("head_id", head_id, 0);
 
     Channel *d = NULL;
 
     try {
 
-        d = Channel::Create(sensor_ip);
-	if (NULL == d) {
-            ROS_ERROR("multisense_ros: failed to create communication channel to sensor @ \"%s\"",
-                      sensor_ip.c_str());
+        RemoteHeadChannel rh_channel = 0;
+        switch(head_id) {
+            case 0:
+                rh_channel = Remote_Head_0;
+                break;
+            case 1:
+                rh_channel = Remote_Head_1;
+                break;
+            case 2:
+                rh_channel = Remote_Head_2;
+                break;
+            case 3:
+                rh_channel = Remote_Head_3;
+                break;
+            default:
+                rh_channel = Remote_Head_VPB;
+                break;
+        }
+
+        d = Channel::Create(sensor_ip, rh_channel);
+        if (NULL == d) {
+            ROS_ERROR("multisense_ros: failed to create communication channel to sensor @ \"%s\" with head ID %d",
+                      sensor_ip.c_str(), rh_channel);
             return -2;
         }
 


### PR DESCRIPTION
Stacked behind #44

- Handle apriltag detection messages from the multisense camera and publish as custom ROS messages
- Add dynamic reconfigure of apriltag parameters (parameters will be hidden if `Source_AprilTag_Detections` is not available on the camera)