### PR TITLE
fix: changed standard to c++17 because of std::shared_mutex

### DIFF
--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -1,9 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(multisense_ros)
 
-# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11)
+    # Default to C++17
+    set(CMAKE_CXX_STANDARD 17)
+  else()
+    # Default to C++14
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(multisense_ros)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
```
In file included from /usr/include/log4cxx/log4cxx.h:45,
                 from /usr/include/log4cxx/logstring.h:28,
                 from /usr/include/log4cxx/level.h:22,
                 from /usr/include/ros/console.h:46,
                 from /usr/include/ros/ros.h:40,
                 from /home/fpasqualini/work/minibot/catkin_ws/src/minibot_meta/multisense_ros/multisense_ros/include/multisense_ros/color_laser.h:41,
                 from /home/fpasqualini/work/minibot/catkin_ws/src/minibot_meta/multisense_ros/multisense_ros/src/color_laser.cpp:36:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
```

Multiple errors like this appear when using GCC 11 and C++ 14