### PR TITLE
fix: added robot_state_publisher to multisense_bringup deps

### DIFF
--- a/multisense_bringup/package.xml
+++ b/multisense_bringup/package.xml
@@ -12,8 +12,10 @@
 
   <build_depend>multisense_ros</build_depend>
   <build_depend>multisense_description</build_depend>
+  <build_depend>robot_state_publisher</build_depend>
 
   <run_depend>multisense_ros</run_depend>
   <run_depend>multisense_description</run_depend>
+  <run_depend>robot_state_publisher</run_depend>  
 
 </package>


### PR DESCRIPTION
Launch file validation requires all included packages to be dependencies