### PR TITLE
Fix logic for IMU message publishing

### DIFF
--- a/multisense_ros/include/multisense_ros/imu.h
+++ b/multisense_ros/include/multisense_ros/imu.h
@@ -102,6 +102,8 @@ private:
     const std::string gyro_frameId_;
     const std::string mag_frameId_;
 
+    bool next_gen_camera_;
+
 };
 
 }

--- a/multisense_ros/include/multisense_ros/imu.h
+++ b/multisense_ros/include/multisense_ros/imu.h
@@ -98,9 +98,9 @@ private:
     //
     // TF prefix and frame ID's
     const std::string tf_prefix_;
-    const std::string accel_frameId_;
-    const std::string gyro_frameId_;
-    const std::string mag_frameId_;
+    std::string accel_frameId_;
+    std::string gyro_frameId_;
+    std::string mag_frameId_;
 
     bool next_gen_camera_;
 

--- a/multisense_ros/src/camera_utilities.cpp
+++ b/multisense_ros/src/camera_utilities.cpp
@@ -103,7 +103,7 @@ Eigen::Matrix4d makeQ(const crl::multisense::image::Config& config,
     const auto fy = calibration.left.P[1][1] * scale.y_scale;
     const auto cy = calibration.left.P[1][2] * scale.y_scale;
     const auto tx = calibration.right.P[0][3] / calibration.right.P[0][0];
-    const auto cx_prime = calibration.left.P[0][2] * scale.x_scale;
+    const auto cx_prime = calibration.right.P[0][2] * scale.x_scale;
 
     q_matrix(0,0) =  fy * tx;
     q_matrix(1,1) =  fx * tx;

--- a/multisense_ros/src/imu.cpp
+++ b/multisense_ros/src/imu.cpp
@@ -282,8 +282,7 @@ void Imu::imuCallback(const imu::Header& header)
             break;
         case imu::Sample::Type_Magnetometer:
 
-            if (!next_gen_camera_)
-            {
+            if (!next_gen_camera_) {
                 if (mag_subscribers > 0)
                     magnetometer_pub_.publish(msg);
 

--- a/multisense_ros/src/imu.cpp
+++ b/multisense_ros/src/imu.cpp
@@ -72,13 +72,6 @@ Imu::Imu(Channel* driver, std::string tf_prefix) :
 {
 
     //
-    // Initialize the sensor_msgs::Imu topic
-    // We will publish the data in the accelerometer frame applying the
-    // transform from the /gyro to the /accel frame to the gyroscope data
-
-    imu_message_.header.frame_id = accel_frameId_;
-
-    //
     // Covariance matrix for linear acceleration and angular velocity were
     // generated using 2 minutes of logged data with the default imu
     // settings. Note the angular velocity covariance has the nominal gyro
@@ -180,6 +173,19 @@ Imu::Imu(Channel* driver, std::string tf_prefix) :
                                                       std::bind(&Imu::stopStreams, this));
         driver_->addIsolatedCallback(imuCB, this);
     }
+
+    if (next_gen_camera_)
+    {
+        accel_frameId_ = tf_prefix_ + "/imu";
+        gyro_frameId_ = tf_prefix + "/imu";
+    }
+
+    //
+    // Initialize the sensor_msgs::Imu topic
+    // We will publish the data in the accelerometer frame applying the
+    // transform from the /gyro to the /accel frame to the gyroscope data
+
+    imu_message_.header.frame_id = accel_frameId_;
 
 }
 

--- a/multisense_ros/src/imu.cpp
+++ b/multisense_ros/src/imu.cpp
@@ -193,13 +193,13 @@ void Imu::imuCallback(const imu::Header& header)
 {
     std::vector<imu::Sample>::const_iterator it = header.samples.begin();
 
-    uint32_t accel_subscribers = accelerometer_pub_.getNumSubscribers();
-    uint32_t gyro_subscribers = gyroscope_pub_.getNumSubscribers();
-    uint32_t mag_subscribers = magnetometer_pub_.getNumSubscribers();
-    uint32_t imu_subscribers = imu_pub_.getNumSubscribers();
-    uint32_t accel_vector_subscribers = accelerometer_vector_pub_.getNumSubscribers();
-    uint32_t gyro_vector_subscribers = gyroscope_vector_pub_.getNumSubscribers();
-    uint32_t mag_vector_subscribers = magnetometer_vector_pub_.getNumSubscribers();
+    const uint32_t accel_subscribers = accelerometer_pub_.getNumSubscribers();
+    const uint32_t gyro_subscribers = gyroscope_pub_.getNumSubscribers();
+    const uint32_t mag_subscribers = next_gen_camera_ ? 0 : magnetometer_pub_.getNumSubscribers();
+    const uint32_t imu_subscribers = imu_pub_.getNumSubscribers();
+    const uint32_t accel_vector_subscribers = accelerometer_vector_pub_.getNumSubscribers();
+    const uint32_t gyro_vector_subscribers = gyroscope_vector_pub_.getNumSubscribers();
+    const uint32_t mag_vector_subscribers = next_gen_camera_ ? 0 : magnetometer_vector_pub_.getNumSubscribers();
 
     for(; it != header.samples.end(); ++it) {
 
@@ -282,13 +282,15 @@ void Imu::imuCallback(const imu::Header& header)
             break;
         case imu::Sample::Type_Magnetometer:
 
+            if (!next_gen_camera_)
+            {
+                if (mag_subscribers > 0)
+                    magnetometer_pub_.publish(msg);
 
-            if (mag_subscribers > 0)
-                magnetometer_pub_.publish(msg);
-
-            if (mag_vector_subscribers > 0) {
-                vector_msg.header.frame_id = mag_frameId_;
-                magnetometer_vector_pub_.publish(vector_msg);
+                if (mag_vector_subscribers > 0) {
+                    vector_msg.header.frame_id = mag_frameId_;
+                    magnetometer_vector_pub_.publish(vector_msg);
+                }
             }
 
             break;


### PR DESCRIPTION
On next-gen cameras IMU and gyro data is captured with the same timestamp. Make sure we only publish one IMU message if this is the case. 

Note this needs to be tested on both old and new cameras