### PR TITLE
Add channel statistics topic

### DIFF
--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -46,6 +46,7 @@ generate_dynamic_reconfigure_options(cfg/multisense.cfg)
 
 add_message_files(DIRECTORY msg
                   FILES
+                  ChannelStatistics.msg
                   DeviceInfo.msg
                   RawCamConfig.msg
                   RawImuData.msg
@@ -94,6 +95,7 @@ add_library(${PROJECT_NAME} src/camera.cpp
                             src/pps.cpp
                             src/point_cloud_utilities.cpp
                             src/status.cpp
+                            src/statistics.cpp
                             src/reconfigure.cpp
                             src/ground_surface_utilities.cpp)
 

--- a/multisense_ros/include/multisense_ros/statistics.h
+++ b/multisense_ros/include/multisense_ros/statistics.h
@@ -1,0 +1,88 @@
+/**
+ * @file statistics.h
+ *
+ * Copyright 2023
+ * Carnegie Robotics, LLC
+ * 4501 Hatfield Street, Pittsburgh, PA 15201
+ * http://www.carnegierobotics.com
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Carnegie Robotics, LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CARNEGIE ROBOTICS, LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#ifndef MULTISENSE_ROS_STATISTICS_H
+#define MULTISENSE_ROS_STATISTICS_H
+
+#include <ros/ros.h>
+
+#include <multisense_lib/MultiSenseChannel.hh>
+
+namespace multisense_ros {
+
+class Statistics {
+public:
+
+    Statistics(crl::multisense::Channel* driver);
+    ~Statistics();
+
+private:
+
+    //
+    // CRL sensor API
+
+    crl::multisense::Channel* driver_;
+
+    //
+    // Driver nodes
+
+    ros::NodeHandle device_nh_;
+
+    //
+    // Channel Statistics publisher
+
+    ros::Publisher statistics_pub_;
+
+    //
+    // A timer to query our device statistics at a fixed rate
+
+    ros::Timer statistics_timer_;
+
+    //
+    // The callback used to query the device statistics in the timer routine
+
+    void queryStatistics(const ros::TimerEvent& event);
+
+
+    //
+    // Publish control
+
+    int32_t subscribers_;
+    void connect();
+    void disconnect();
+};
+
+}
+
+#endif
+

--- a/multisense_ros/msg/ChannelStatistics.msg
+++ b/multisense_ros/msg/ChannelStatistics.msg
@@ -1,0 +1,33 @@
+Header header
+
+# The number of missed headers that the channel has observed
+uint64 num_missed_headers
+
+# The number of dropped UDP assemblers that the channel has observed
+uint64 num_dropped_assemblers
+
+# The number of image metadata messages were received
+uint64 num_image_meta_data
+
+# The number of images that were dispatched
+uint64 num_dispatched_image
+
+# The number of lidar scans that were dispatched
+uint64 num_dispatched_lidar
+
+# The number of dispatched PPS messages
+uint64 num_dispatched_pps
+
+# The number of dispatched IMU messages
+uint64 num_dispatched_imu
+
+# The number of dispatched compressed images
+uint64 num_dispatched_compressed_image
+
+# The number of dispatched ground surface spline events
+uint64 num_dispatched_ground_surface_spline
+
+# The number of dispatched april tag detection events
+uint64 num_dispatched_april_tag_detections
+
+

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -38,6 +38,7 @@
 #include <multisense_ros/pps.h>
 #include <multisense_ros/imu.h>
 #include <multisense_ros/status.h>
+#include <multisense_ros/statistics.h>
 #include <multisense_ros/reconfigure.h>
 #include <ros/ros.h>
 
@@ -109,6 +110,7 @@ int main(int argc, char** argvPP)
             multisense_ros::Pps          pps(d);
             multisense_ros::Imu          imu(d, tf_prefix);
             multisense_ros::Status       status(d);
+            multisense_ros::Statistics   statistics(d);
             multisense_ros::Reconfigure  rec(d,
                                              std::bind(&multisense_ros::Camera::updateConfig, &camera, std::placeholders::_1),
                                              std::bind(&multisense_ros::Camera::borderClipChanged, &camera,

--- a/multisense_ros/src/statistics.cpp
+++ b/multisense_ros/src/statistics.cpp
@@ -1,0 +1,99 @@
+/**
+ * @file statistics.cpp
+ *
+ * Copyright 2023
+ * Carnegie Robotics, LLC
+ * 4501 Hatfield Street, Pittsburgh, PA 15201
+ * http://www.carnegierobotics.com
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Carnegie Robotics, LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CARNEGIE ROBOTICS, LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#include <multisense_ros/statistics.h>
+
+#include <multisense_ros/ChannelStatistics.h>
+
+namespace multisense_ros {
+
+Statistics::Statistics(crl::multisense::Channel* driver):
+    driver_(driver),
+    device_nh_(""),
+    statistics_pub_(),
+    statistics_timer_(),
+    subscribers_(0)
+{
+    statistics_pub_ = device_nh_.advertise<multisense_ros::ChannelStatistics>("channel_statistics", 5,
+                                                        std::bind(&Statistics::connect, this),
+                                                        std::bind(&Statistics::disconnect, this));
+
+    statistics_timer_ = device_nh_.createTimer(ros::Duration(1), &Statistics::queryStatistics, this);
+}
+
+Statistics::~Statistics()
+{
+}
+
+void Statistics::queryStatistics(const ros::TimerEvent& event)
+{
+    (void) event;
+
+    if (subscribers_ <= 0)
+        return;
+
+    if (NULL != driver_)
+    {
+        crl::multisense::system::ChannelStatistics statistics = driver_->getStats();
+
+        multisense_ros::ChannelStatistics statisticsMsg;
+
+        statisticsMsg.header.stamp = ros::Time::now();
+
+        statisticsMsg.num_missed_headers = statistics.numMissedHeaders;
+        statisticsMsg.num_dropped_assemblers = statistics.numDroppedAssemblers;
+        statisticsMsg.num_image_meta_data = statistics.numImageMetaData;
+        statisticsMsg.num_dispatched_image = statistics.numDispatchedImage;
+        statisticsMsg.num_dispatched_lidar = statistics.numDispatchedLidar;
+        statisticsMsg.num_dispatched_pps = statistics.numDispatchedPps;
+        statisticsMsg.num_dispatched_imu = statistics.numDispatchedImu;
+        statisticsMsg.num_dispatched_compressed_image = statistics.numDispatchedCompressedImage;
+        statisticsMsg.num_dispatched_ground_surface_spline = statistics.numDispatchedGroundSurfaceSpline;
+        statisticsMsg.num_dispatched_april_tag_detections = statistics.numDispatchedAprilTagDetections;
+
+        statistics_pub_.publish(statisticsMsg);
+    }
+}
+
+void Statistics::connect()
+{
+    __sync_fetch_and_add(&subscribers_, 1);
+}
+
+void Statistics::disconnect()
+{
+    __sync_fetch_and_sub(&subscribers_, 1);
+}
+
+
+}


### PR DESCRIPTION
This PR introduces a `/<driver_name>/channel_statistics` topic for MultiSense ROS drivers.
This is particularly useful in debugging image loss, by means of separating the LibMultiSense channel and the ROS stack via statistics about the underlying channel object.