### PR TITLE
Add doc strings to multisense launch parameters

### DIFF
--- a/multisense_bringup/multisense.launch
+++ b/multisense_bringup/multisense.launch
@@ -1,17 +1,25 @@
 <launch>
 
-  <!-- Valid Sensor types are SL, S7, S7S, S21, S27, S30, BCAM,
-                              remote_head_vpb, remote_head_stereo, and remote_head_monocam -->
-
-  <arg name="ip_address" default="10.66.171.21" />
-  <arg name="namespace"  default="multisense" />
-  <arg name="mtu"        default="7200" />
-  <arg name="sensor"     default="S21" />
-  <arg name="head_id"    default="-1" />
-  <arg name="launch_robot_state_publisher" default="true" />
-  <arg name="launch_color_laser_publisher" default="false" />
-  <arg name="nodes_prefix" default="$(arg namespace)" />
-  <arg name="tf_prefix" default="$(arg namespace)" />
+  <arg name="ip_address" default="10.66.171.21" doc="IP address of the multisense being connected to" />
+  <arg name="namespace"  default="multisense"   doc="Namespace for all topics for this multisense instance" />
+  <arg name="mtu"        default="7200"         doc="The maximum packet size that image data will be broken into when sent from the multisense. Setting to values above network adapter MTU will block image data from camera" />
+  <arg name="sensor"     default="S21"          doc="The camera type. Used to determine the URDF model that will be loaded.
+  Options:
+    SL,
+    S7,
+    S7S,
+    S21,
+    S27,
+    S30,
+    BCAM,
+    remote_head_vpb,
+    remote_head_stereo,
+    remote_head_mono" />
+  <arg name="head_id"    default="-1" doc="Head ID to be used when connecting to remote head cameras. -1 for VPB or traditional MultiSense cameras" />
+  <arg name="launch_robot_state_publisher" default="true" doc="Set true to launch the state publisher" />
+  <arg name="launch_color_laser_publisher" default="false" doc="Set true to launch the laser colorization publisher for SL cameras" />
+  <arg name="nodes_prefix" default="$(arg namespace)" doc="Prefix used for naming the nodes on launch" />
+  <arg name="tf_prefix" default="$(arg namespace)" doc="Prefix used for transform names" />
 
   <!-- Robot state publisher -->
   <group if = "$(arg launch_robot_state_publisher)">

--- a/multisense_bringup/remote_head.launch
+++ b/multisense_bringup/remote_head.launch
@@ -1,13 +1,14 @@
 <launch>
 
-  <arg name="ip_address" default="10.66.171.21" />
-  <arg name="mtu"        default="7200" />
+  <arg name="ip_address" default="10.66.171.21" doc="IP address of the multisense being connected to" />
+  <arg name="mtu"        default="7200"         doc="The maximum packet size that image data will be broken into when sent from the multisense.
+  Setting to values above network adapter MTU will block image data from camera" />
 
-  <arg name="launch_vpb" default="true" />
-  <arg name="launch_head0" default="true" />
-  <arg name="launch_head1" default="true" />
-  <arg name="launch_head2" default="true" />
-  <arg name="launch_head3" default="true" />
+  <arg name="launch_vpb"   default="true" doc="Set to false to prevent launching a multisense driver instance for VPB" />
+  <arg name="launch_head0" default="true" doc="Set to false to prevent launching a multisense driver instance for remote head channel 0" />
+  <arg name="launch_head1" default="true" doc="Set to false to prevent launching a multisense driver instance for remote head channel 1" />
+  <arg name="launch_head2" default="true" doc="Set to false to prevent launching a multisense driver instance for remote head channel 2" />
+  <arg name="launch_head3" default="true" doc="Set to false to prevent launching a multisense driver instance for remote head channel 3" />
 
   <arg name="vpb_namespace"    default="multisense_vpb" />
   <arg name="head0_namespace"  default="remote_head_0" />
@@ -15,12 +16,11 @@
   <arg name="head2_namespace"  default="remote_head_2" />
   <arg name="head3_namespace"  default="remote_head_3" />
 
-  <!-- Valid Sensor types for remote heads are remote_head_vpb, remote_head_stereo, remote_head_monocam -->
-  <arg name="vpb_sensor"       default="remote_head_vpb" />
-  <arg name="head0_sensor"     default="remote_head_stereo" />
-  <arg name="head1_sensor"     default="remote_head_stereo" />
-  <arg name="head2_sensor"     default="remote_head_stereo" />
-  <arg name="head3_sensor"     default="remote_head_stereo" />
+  <arg name="vpb_sensor"       default="remote_head_vpb"    doc="VPB Sensor type, should always be remote_head_vpb" />
+  <arg name="head0_sensor"     default="remote_head_stereo" doc="Remote head 0 sensor type. Options: remote_head_stereo, remote_head_monocam" />
+  <arg name="head1_sensor"     default="remote_head_stereo" doc="Remote head 1 sensor type. Options: remote_head_stereo, remote_head_monocam" />
+  <arg name="head2_sensor"     default="remote_head_stereo" doc="Remote head 2 sensor type. Options: remote_head_stereo, remote_head_monocam" />
+  <arg name="head3_sensor"     default="remote_head_stereo" doc="Remote head 3 sensor type. Options: remote_head_stereo, remote_head_monocam" />
 
   <arg name="vpb_nodes_prefix"   default="$(arg vpb_namespace)" />
   <arg name="head0_nodes_prefix" default="$(arg head0_namespace)" />


### PR DESCRIPTION
Add docs for arguments in the launch files

Docs can be viewed by the user by running `roslaunch multisense_bringup multisense.launch --ros-args`