### PR TITLE
Set default MTU from 7200 to 1500

### DIFF
--- a/multisense_bringup/multisense.launch
+++ b/multisense_bringup/multisense.launch
@@ -6,7 +6,7 @@
 
   <arg name="ip_address" default="10.66.171.21" doc="IP address of the multisense being connected to" />
   <arg name="namespace"  default="multisense"   doc="Namespace for all topics for this multisense instance" />
-  <arg name="mtu"        default="7200"         doc="The maximum packet size that image data will be broken into when sent from the multisense. Setting to values above network adapter MTU will block image data from camera" />
+  <arg name="mtu"        default="1500"         doc="The maximum packet size that image data will be broken into when sent from the multisense. Setting to values above network adapter MTU will block image data from camera" />
   <arg name="sensor"     default="S30"          doc="The camera type. Used to determine the URDF model that will be loaded.
   Options:
     SL,

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -61,7 +61,7 @@ int main(int argc, char** argvPP)
 
     nh_private_.param<std::string>("sensor_ip", sensor_ip, "10.66.171.21");
     nh_private_.param<std::string>("tf_prefix", tf_prefix, "multisense");
-    nh_private_.param<int>("sensor_mtu", sensor_mtu, 7200);
+    nh_private_.param<int>("sensor_mtu", sensor_mtu, 1500);
     nh_private_.param<int>("head_id", head_id, -1);
 
     Channel *d = NULL;


### PR DESCRIPTION
NOTE: this should be paired with this PR in LibMultiSense once it lands on main: https://github.com/carnegierobotics/LibMultiSense/pull/165 

This PR modifies the default mtu from 7200 to 1500. Jumbo frame support regularly trips up users and prevents them from being able to stream. The performance loss between 1500 and 7200 is theoretically in the low single digit percentages, so it is not worth the trouble of setting the default to a value that is difficult to support and usually not necessary

This should significantly improve most user's ability to get a camera running for the first time, and reduce the amount of debugging it takes to understand why a camera will not stream images
