### PR TITLE
Add connection timeout and respawn options

### DIFF
--- a/multisense_bringup/multisense.launch
+++ b/multisense_bringup/multisense.launch
@@ -27,7 +27,7 @@
   <arg name="launch_color_laser_publisher" default="false" doc="Set true to launch the laser colorization publisher for SL cameras" />
   <arg name="nodes_prefix" default="$(arg namespace)" doc="Prefix used for naming the nodes on launch" />
   <arg name="tf_prefix" default="$(arg namespace)" doc="Prefix used for transform names" />
-  <arg name="camera_timeout_s" default="-1" doc="Camera driver will shut down if it does not hear from the camera after this many seconds. (Disabled when &lt;= 0)" />
+  <arg name="camera_timeout_s" default="-1" doc="Camera driver will shut down if it does not hear from the camera after this many seconds. (Disabled when &lt;=0. Values &lt;3 may result in false positives)" />
   <arg name="respawn" default="false" doc="Respawn the multisense node if the camera disconnects" />
 
   <!-- Robot state publisher -->

--- a/multisense_bringup/multisense.launch
+++ b/multisense_bringup/multisense.launch
@@ -27,28 +27,31 @@
   <arg name="launch_color_laser_publisher" default="false" doc="Set true to launch the laser colorization publisher for SL cameras" />
   <arg name="nodes_prefix" default="$(arg namespace)" doc="Prefix used for naming the nodes on launch" />
   <arg name="tf_prefix" default="$(arg namespace)" doc="Prefix used for transform names" />
+  <arg name="camera_timeout_s" default="-1" doc="Camera driver will shut down if it does not hear from the camera after this many seconds. (Disabled when &lt;= 0)" />
+  <arg name="respawn" default="false" doc="Respawn the multisense node if the camera disconnects" />
 
   <!-- Robot state publisher -->
   <group if = "$(arg launch_robot_state_publisher)">
     <param name="robot_description"
-          command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg sensor)/standalone.urdf.xacro' name:=$(arg namespace)"/>
-    <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg nodes_prefix)_state_publisher">
+          command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg sensor)/standalone.urdf.xacro' name:=$(arg namespace)" />
+    <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg nodes_prefix)_state_publisher" respawn="$(arg respawn)" >
       <param name="publish_frequency" type="double" value="50.0" />
       <remap from="joint_states" to="/$(arg namespace)/joint_states" />
     </node>
   </group>
 
   <!-- ROS Driver -->
-   <node pkg="multisense_ros" ns="$(arg namespace)" type="ros_driver" name="$(arg nodes_prefix)_driver" output="screen">
+   <node pkg="multisense_ros" ns="$(arg namespace)" type="ros_driver" name="$(arg nodes_prefix)_driver" output="screen" respawn="$(arg respawn)" >
      <param name="sensor_ip"   value="$(arg ip_address)" />
      <param name="sensor_mtu"  value="$(arg mtu)" />
      <param name="tf_prefix"  value="$(arg tf_prefix)" />
      <param name="head_id"  value="$(arg head_id)" />
+     <param name="camera_timeout_s"  value="$(arg camera_timeout_s)" />
   </node>
 
   <!-- Color Laser PointCloud Publisher -->
   <group if = "$(arg launch_color_laser_publisher)">
-    <node pkg="multisense_ros" ns="$(arg namespace)" type="color_laser_publisher" name="$(arg nodes_prefix)_color_laser_publisher" output="screen">
+    <node pkg="multisense_ros" ns="$(arg namespace)" type="color_laser_publisher" name="$(arg nodes_prefix)_color_laser_publisher" output="screen" respawn="$(arg respawn)" >
       <remap from="image_rect_color" to="/$(arg namespace)/left/image_rect_color" />
       <remap from="lidar_points2" to="/$(arg namespace)/lidar_points2" />
       <remap from="camera_info" to="/$(arg namespace)/left/image_rect_color/camera_info" />
@@ -56,7 +59,7 @@
   </group>
 
   <node if="$(arg show_rviz)" type="rviz" name="rviz" pkg="rviz" required="false"
-  launch-prefix="bash -c 'sleep 5; $0 $@' "
-  args="-d $(arg rviz_config)"/>
+    launch-prefix="bash -c 'sleep 5; $0 $@' "
+    args="-d $(arg rviz_config)"/>
 
 </launch>

--- a/multisense_bringup/remote_head.launch
+++ b/multisense_bringup/remote_head.launch
@@ -36,23 +36,26 @@
   <arg name="head3_tf_prefix" default="$(arg head3_namespace)" />
 
   <arg name="launch_robot_state_publisher" default="true" />
+  <arg name="camera_timeout_s" default="-1" doc="Camera driver will shut down if it does not hear from the camera after this many seconds. (Disabled when &lt;= 0)" />
+  <arg name="respawn" default="false" doc="Respawn the multisense node if the camera disconnects" />
 
   <!-- Remote Head VPB Launch-->
   <group if = "$(arg launch_vpb)">
 
     <!-- ROS Driver -->
-    <node pkg="multisense_ros" ns="$(arg vpb_namespace)" type="ros_driver" name="$(arg vpb_nodes_prefix)_driver" output="screen" required="true">
+    <node pkg="multisense_ros" ns="$(arg vpb_namespace)" type="ros_driver" name="$(arg vpb_nodes_prefix)_driver" output="screen" required="true" respawn="$(arg respawn)" >
       <param name="sensor_ip" value="$(arg ip_address)" />
       <param name="sensor_mtu" value="$(arg mtu)" />
       <param name="tf_prefix"  value="$(arg vpb_tf_prefix)" />
       <param name="head_id"  value="-1" />
+      <param name="camera_timeout_s"  value="$(arg camera_timeout_s)" />
     </node>
 
     <!-- Robot state publisher -->
     <group if = "$(arg launch_robot_state_publisher)">
       <param name="robot_description"
             command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg vpb_sensor)/standalone.urdf.xacro' name:=$(arg vpb_namespace)"/>
-      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg vpb_nodes_prefix)_state_publisher" required="true">
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg vpb_nodes_prefix)_state_publisher" required="true" respawn="$(arg respawn)" >
         <param name="publish_frequency" type="double" value="50.0" />
         <remap from="joint_states" to="/$(arg vpb_namespace)/joint_states" />
       </node>
@@ -65,18 +68,19 @@
   <group if = "$(arg launch_head0)">
 
     <!-- ROS Driver -->
-    <node pkg="multisense_ros" ns="$(arg head0_namespace)" type="ros_driver" name="$(arg head0_nodes_prefix)_driver" output="screen" required="true">
+    <node pkg="multisense_ros" ns="$(arg head0_namespace)" type="ros_driver" name="$(arg head0_nodes_prefix)_driver" output="screen" required="true" respawn="$(arg respawn)" >
       <param name="sensor_ip" value="$(arg ip_address)" />
       <param name="sensor_mtu" value="$(arg mtu)" />
       <param name="tf_prefix"  value="$(arg head0_tf_prefix)" />
       <param name="head_id"  value="0" />
+      <param name="camera_timeout_s"  value="$(arg camera_timeout_s)" />
     </node>
 
     <!-- Robot state publisher -->
     <group if = "$(arg launch_robot_state_publisher)">
       <param name="robot_description"
             command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg head0_sensor)/standalone.urdf.xacro' name:=$(arg head0_namespace)"/>
-      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head0_nodes_prefix)_state_publisher" required="true">
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head0_nodes_prefix)_state_publisher" required="true" respawn="$(arg respawn)" >
         <param name="publish_frequency" type="double" value="50.0" />
         <remap from="joint_states" to="/$(arg head0_namespace)/joint_states" />
       </node>
@@ -89,18 +93,19 @@
   <group if = "$(arg launch_head1)">
 
     <!-- ROS Driver -->
-    <node pkg="multisense_ros" ns="$(arg head1_namespace)" type="ros_driver" name="$(arg head1_nodes_prefix)_driver" output="screen" required="true">
+    <node pkg="multisense_ros" ns="$(arg head1_namespace)" type="ros_driver" name="$(arg head1_nodes_prefix)_driver" output="screen" required="true" respawn="$(arg respawn)" >
       <param name="sensor_ip" value="$(arg ip_address)" />
       <param name="sensor_mtu" value="$(arg mtu)" />
       <param name="tf_prefix"  value="$(arg head1_tf_prefix)" />
       <param name="head_id"  value="1" />
+      <param name="camera_timeout_s"  value="$(arg camera_timeout_s)" />
     </node>
 
     <!-- Robot state publisher -->
     <group if = "$(arg launch_robot_state_publisher)">
       <param name="robot_description"
             command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg head1_sensor)/standalone.urdf.xacro' name:=$(arg head1_namespace)"/>
-      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head1_nodes_prefix)_state_publisher" required="true">
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head1_nodes_prefix)_state_publisher" required="true" respawn="$(arg respawn)" >
         <param name="publish_frequency" type="double" value="50.0" />
         <remap from="joint_states" to="/$(arg head1_namespace)/joint_states" />
       </node>
@@ -113,18 +118,19 @@
   <group if = "$(arg launch_head2)">
 
     <!-- ROS Driver -->
-    <node pkg="multisense_ros" ns="$(arg head2_namespace)" type="ros_driver" name="$(arg head2_nodes_prefix)_driver" output="screen" required="true">
+    <node pkg="multisense_ros" ns="$(arg head2_namespace)" type="ros_driver" name="$(arg head2_nodes_prefix)_driver" output="screen" required="true" respawn="$(arg respawn)" >
       <param name="sensor_ip" value="$(arg ip_address)" />
       <param name="sensor_mtu" value="$(arg mtu)" />
       <param name="tf_prefix"  value="$(arg head2_tf_prefix)" />
       <param name="head_id"  value="2" />
+      <param name="camera_timeout_s"  value="$(arg camera_timeout_s)" />
     </node>
 
     <!-- Robot state publisher -->
     <group if = "$(arg launch_robot_state_publisher)">
       <param name="robot_description"
             command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg head2_sensor)/standalone.urdf.xacro' name:=$(arg head2_namespace)"/>
-      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head2_nodes_prefix)_state_publisher" required="true">
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head2_nodes_prefix)_state_publisher" required="true" respawn="$(arg respawn)" >
         <param name="publish_frequency" type="double" value="50.0" />
         <remap from="joint_states" to="/$(arg head2_namespace)/joint_states" />
       </node>
@@ -137,18 +143,19 @@
   <group if = "$(arg launch_head3)">
 
     <!-- ROS Driver -->
-    <node pkg="multisense_ros" ns="$(arg head3_namespace)" type="ros_driver" name="$(arg head3_nodes_prefix)_driver" output="screen" required="true">
+    <node pkg="multisense_ros" ns="$(arg head3_namespace)" type="ros_driver" name="$(arg head3_nodes_prefix)_driver" output="screen" required="true" respawn="$(arg respawn)" >
       <param name="sensor_ip" value="$(arg ip_address)" />
       <param name="sensor_mtu" value="$(arg mtu)" />
       <param name="tf_prefix"  value="$(arg head3_tf_prefix)" />
       <param name="head_id"  value="3" />
+      <param name="camera_timeout_s"  value="$(arg camera_timeout_s)" />
     </node>
 
     <!-- Robot state publisher -->
     <group if = "$(arg launch_robot_state_publisher)">
       <param name="robot_description"
             command="$(find xacro)/xacro '$(find multisense_description)/urdf/multisense$(arg head3_sensor)/standalone.urdf.xacro' name:=$(arg head3_namespace)"/>
-      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head3_nodes_prefix)_state_publisher" required="true">
+      <node pkg="robot_state_publisher" type="robot_state_publisher" name="$(arg head3_nodes_prefix)_state_publisher" required="true" respawn="$(arg respawn)" >
         <param name="publish_frequency" type="double" value="50.0" />
         <remap from="joint_states" to="/$(arg head3_namespace)/joint_states" />
       </node>

--- a/multisense_bringup/remote_head.launch
+++ b/multisense_bringup/remote_head.launch
@@ -36,7 +36,7 @@
   <arg name="head3_tf_prefix" default="$(arg head3_namespace)" />
 
   <arg name="launch_robot_state_publisher" default="true" />
-  <arg name="camera_timeout_s" default="-1" doc="Camera driver will shut down if it does not hear from the camera after this many seconds. (Disabled when &lt;= 0)" />
+  <arg name="camera_timeout_s" default="-1" doc="Camera driver will shut down if it does not hear from the camera after this many seconds. (Disabled when &lt;=0. Values &lt;3 may result in false positives)" />
   <arg name="respawn" default="false" doc="Respawn the multisense node if the camera disconnects" />
 
   <!-- Remote Head VPB Launch-->

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -57,14 +57,14 @@ int main(int argc, char** argvPP)
     std::string   tf_prefix;
     int           sensor_mtu;
     int           head_id;
-    double        timeout_s;
+    int           timeout_s;
 
 
     nh_private_.param<std::string>("sensor_ip", sensor_ip, "10.66.171.21");
     nh_private_.param<std::string>("tf_prefix", tf_prefix, "multisense");
     nh_private_.param<int>("sensor_mtu", sensor_mtu, 1500);
     nh_private_.param<int>("head_id", head_id, -1);
-    nh_private_.param<double>("camera_timeout_s", timeout_s, -1.0);
+    nh_private_.param<int>("camera_timeout_s", timeout_s, -1);
 
     Channel *d = NULL;
 
@@ -126,10 +126,10 @@ int main(int argc, char** argvPP)
 
             ros::Rate rate(50);
             ros::Time last_status{ros::Time::now()};
-            const ros::Duration timeout{timeout_s};
+            const ros::Duration timeout{static_cast<double>(timeout_s)};
 
             ros::Time last_warning{};
-            ros::Duration warn_delay{0.5};
+            ros::Duration warn_delay{1.0};
             while (ros::ok()) {
                 ros::spinOnce();
 
@@ -138,7 +138,7 @@ int main(int argc, char** argvPP)
                 if (Status_Ok != status_result) {
 
                     if (ros::Time::now() - last_warning > warn_delay) {
-                        ROS_WARN("multisense_ros: lost connection with camera");
+                        ROS_WARN("multisense_ros: missed camera status message");
                         last_warning = ros::Time::now();
                     }
 
@@ -149,6 +149,7 @@ int main(int argc, char** argvPP)
                     }
 
                 } else {
+                    last_warning = ros::Time::now();
                     last_status = ros::Time::now();
                 }
 

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -129,7 +129,7 @@ int main(int argc, char** argvPP)
             const ros::Duration timeout{static_cast<double>(timeout_s)};
 
             ros::Time last_warning{};
-            ros::Duration warn_delay{1.0};
+            ros::Duration warn_delay{1.1};
             while (ros::ok()) {
                 ros::spinOnce();
 


### PR DESCRIPTION
The `camera_timeout_s` will cause the multisense node to shut down if it cannot communicate with the camera for `camera_timeout_s` seconds. Setting this value <=0 will disable the timeout check 

The `respawn` being true means the multisense launch file will attempt to re-launch the node if it is shut down

Used together these two options can be used to automatically re-connect to a camera after it is disconnected/reconnected or power cycled