### PR TITLE
Fix Aux Auto Whitebalance Settings

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -226,11 +226,11 @@ for feature_name, feature in SupportedFeatures.__members__.items():
         #endif
 
         if cfg.aux:
-            gen.add("auto_white_balance", bool_t, 0, "AutoWhiteBalance", True)
-            gen.add("auto_white_balance_decay", int_t, 0, "AutoWhiteBalanceDecay", 3, 0, 20)
-            gen.add("auto_white_balance_thresh", double_t, 0, "AutoWhiteBalanceThresh", 0.5, 0.0, 1.0)
-            gen.add("white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
-            gen.add("white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
+            gen.add("aux_auto_white_balance", bool_t, 0, "AutoWhiteBalance", True)
+            gen.add("aux_auto_white_balance_decay", int_t, 0, "AutoWhiteBalanceDecay", 3, 0, 20)
+            gen.add("aux_auto_white_balance_thresh", double_t, 0, "AutoWhiteBalanceThresh", 0.5, 0.0, 1.0)
+            gen.add("aux_white_balance_red", double_t, 0, "WhiteBalanceScaleRed", 1.0, 0.25, 4.0)
+            gen.add("aux_white_balance_blue", double_t, 0, "WhiteBalanceScaleBlue", 1.0, 0.25, 4.0)
             gen.add("aux_enable_sharpening", bool_t, 0, "EnableAuxSharpening", False)
             gen.add("aux_sharpening_percentage", double_t, 0, "AuxSharpeningPercentage", 0.0, 0.0, 100.0)
             gen.add("aux_sharpening_limit", int_t, 0, "AuxSharpeningLimit", 0, 0, 100)

--- a/multisense_ros/src/reconfigure.cpp
+++ b/multisense_ros/src/reconfigure.cpp
@@ -490,6 +490,11 @@ template<class T> void Reconfigure::configureAuxCamera(const T& dyn)
         auxConfig.setSharpeningPercentage(dyn.aux_sharpening_percentage);
         auxConfig.setSharpeningLimit(dyn.aux_sharpening_limit);
 
+        auxConfig.setWhiteBalance(dyn.aux_white_balance_red, dyn.aux_white_balance_blue);
+        auxConfig.setAutoWhiteBalance(dyn.aux_auto_white_balance);
+        auxConfig.setAutoWhiteBalanceDecay(dyn.aux_auto_white_balance_decay);
+        auxConfig.setAutoWhiteBalanceThresh(dyn.aux_auto_white_balance_thresh);
+
 
         if (dyn.aux_roi_auto_exposure) {
             if (roi_supported_) {
@@ -1056,7 +1061,6 @@ template<class T> void Reconfigure::configureRemoteHeadSyncGroups(const T& dyn)
         configureDetailDisparityStereoProfile(profile, dyn);    \
         configureFullResAuxStereoProfile(profile, dyn);         \
         cfg.setCameraProfile(profile);                          \
-        configureAutoWhiteBalance(cfg, dyn);                    \
         configureGamma(cfg, dyn);                               \
         configureCamera(cfg, dyn);                              \
         configureBorderClip(dyn);                               \
@@ -1090,7 +1094,6 @@ template<class T> void Reconfigure::configureRemoteHeadSyncGroups(const T& dyn)
         configureDetailDisparityStereoProfile(profile, dyn);    \
         configureFullResAuxStereoProfile(profile, dyn);         \
         cfg.setCameraProfile(profile);                          \
-        configureAutoWhiteBalance(cfg, dyn);                    \
         configureGamma(cfg, dyn);                               \
         configureCamera(cfg, dyn);                              \
         configureBorderClip(dyn);                               \
@@ -1110,7 +1113,6 @@ template<class T> void Reconfigure::configureRemoteHeadSyncGroups(const T& dyn)
         configureGroundSurfaceStereoProfile(profile, dyn);      \
         configureFullResAuxStereoProfile(profile, dyn);         \
         cfg.setCameraProfile(profile);                          \
-        configureAutoWhiteBalance(cfg, dyn);                    \
         configureGamma(cfg, dyn);                               \
         configureCamera(cfg, dyn);                              \
         configureBorderClip(dyn);                               \
@@ -1148,7 +1150,6 @@ template<class T> void Reconfigure::configureRemoteHeadSyncGroups(const T& dyn)
         configureGroundSurfaceStereoProfile(profile, dyn);      \
         configureFullResAuxStereoProfile(profile, dyn);         \
         cfg.setCameraProfile(profile);                          \
-        configureAutoWhiteBalance(cfg, dyn);                    \
         configureGamma(cfg, dyn);                               \
         configureCamera(cfg, dyn);                              \
         configureBorderClip(dyn);                               \


### PR DESCRIPTION
Previously the auto-whitebalance settings were not being applied to the aux camera when set. This PR should resolve that problem