### PR TITLE
multisense_bringup: update default config with  'modern' naming for aux streams

### DIFF
--- a/multisense_bringup/rviz_config.rviz
+++ b/multisense_bringup/rviz_config.rviz
@@ -76,11 +76,11 @@ Visualization Manager:
       Value: false
     - Class: rviz/Image
       Enabled: false
-      Image Topic: /multisense/left/image_color
+      Image Topic: /multisense/aux/image_color
       Max Value: 1
       Median window: 5
       Min Value: 0
-      Name: Left Color
+      Name: Color
       Normalize Range: true
       Queue Size: 2
       Transport Hint: raw
@@ -88,11 +88,11 @@ Visualization Manager:
       Value: false
     - Class: rviz/Image
       Enabled: false
-      Image Topic: /multisense/left/image_rect_color
+      Image Topic: /multisense/aux/image_rect_color
       Max Value: 1
       Median window: 5
       Min Value: 0
-      Name: Left Color Rectified
+      Name: Color Rectified
       Normalize Range: true
       Queue Size: 2
       Transport Hint: raw


### PR DESCRIPTION
Needed to make these changes to get a KS21i/S27 to stream color images. Figure we should update them here or in the driver manuals