### PR TITLE
Update default exposure params to improve image quality

### DIFF
--- a/multisense_ros/cfg/multisense.cfg
+++ b/multisense_ros/cfg/multisense.cfg
@@ -163,7 +163,7 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             gen.add("fps", double_t, 0, "FPS", 10.0, 1.0, 30.0)
             roi_width = 1920
             roi_height = 1200
-            auto_exposure_threshold = 0.95
+            auto_exposure_threshold = 0.85
         #endif
 
         if cfg.name.find('st21_sgm_vga_imu') == -1:
@@ -185,7 +185,7 @@ for feature_name, feature in SupportedFeatures.__members__.items():
         if cfg.name.find('st21_sgm_vga_imu') == -1 and cfg.name.find('remote_head_vpb') == -1:
             if cfg.ar0234:
                 gen.add("gain", double_t, 0, "SensorGain", 1.68421, 1.68421, 16.0)
-                gen.add("gamma", double_t, 0, "SensorGamma", 1.0, 1.0, 2.2)
+                gen.add("gamma", double_t, 0, "SensorGamma", 2.2, 1.0, 2.2)
             else:
                 gen.add("gain", double_t, 0, "SensorGain", 1.0, 1.0, 8.0)
             #endif
@@ -193,7 +193,7 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             gen.add("auto_exposure", bool_t, 0, "AutoExposure", True)
 
             if cfg.ar0234:
-                gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.033, 0.0, 0.033);
+                gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.01, 0.0, 0.033);
             else:
                 gen.add("auto_exposure_max_time", double_t, 0, "AutoExposureMaxTime", 0.5, 0.0, 0.5);
             #endif
@@ -236,9 +236,9 @@ for feature_name, feature in SupportedFeatures.__members__.items():
             gen.add("aux_sharpening_limit", int_t, 0, "AuxSharpeningLimit", 0, 0, 100)
 
             gen.add("aux_gain", double_t, 0, "AuxSensorGain", 1.68421, 1.68421, 16.0)
-            gen.add("aux_gamma", double_t, 0, "AuxSensorGamma", 1.0, 1.0, 2.2)
+            gen.add("aux_gamma", double_t, 0, "AuxSensorGamma", 2.2, 1.0, 2.2)
             gen.add("aux_auto_exposure", bool_t, 0, "AuxAutoExposure", True)
-            gen.add("aux_auto_exposure_max_time", double_t, 0, "AuxAutoExposureMaxTime", 0.033, 0.0, 0.033);
+            gen.add("aux_auto_exposure_max_time", double_t, 0, "AuxAutoExposureMaxTime", 0.01, 0.0, 0.033);
             gen.add("aux_auto_exposure_decay", int_t, 0, "AuxAutoExposureDecay", 7, 0, 10)
             gen.add("aux_auto_exposure_thresh", double_t, 0, "AuxAutoExposureThresh", auto_exposure_threshold, 0.0, 1.0)
             gen.add("aux_auto_exposure_target_intensity", double_t, 0, "AuxAutoExposureTargetIntensity", 0.5, 0.0, 1.0)


### PR DESCRIPTION
Updates the following parameters for both the left/right and aux images

- Default max auto exposure time 10ms
- Default gamma 2.2
- Default auto exposure threshold 85%